### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 /*****************IMPORTANT DRAKVUF SANDBOX LICENSE TERMS*******************
  *                                                                         *
- * DRAKVUF Sandbox (C) 2020 CERT Polska - NASK PIB.                        *
+ * DRAKVUF Sandbox (C) 2019-2020 CERT Polska - NASK PIB.                   *
  *                                                                         *
  * Please note that this program incorporates                              *
  * DRAKVUF (C) 2014-2020 Tamas K Lengyel                                   *

--- a/drakcore/debian/changelog
+++ b/drakcore/debian/changelog
@@ -1,3 +1,5 @@
-drakcore (0.1.0) unstable; urgency=low
-  * Initial public release
- -- Michał Leszczyński <ml@icedev.pl>  Tue, 17 Mar 2020 17:00:00 +0100
+drakcore (0.2.0) unstable; urgency=low
+  * New layout in the web UI
+  * Implemented basic networking support
+  * Implemented ZFS support
+ -- Michał Leszczyński <ml@icedev.pl>  Tue, 23 Apr 2020 04:00:00 +0100

--- a/drakcore/drakcore/frontend/package-lock.json
+++ b/drakcore/drakcore/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "drakcore",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/drakcore/drakcore/frontend/package.json
+++ b/drakcore/drakcore/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drakcore",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "axios": "^0.19.0",

--- a/drakcore/drakcore/frontend/src/App.js
+++ b/drakcore/drakcore/frontend/src/App.js
@@ -95,7 +95,7 @@ class App extends Component {
                 <div className="container-fluid">
                     <div className="row">
                         <div className="col-md-6">
-                            DRAKVUF Sandbox (C) 2020 <a href="https://cert.pl/">CERT Polska</a><br/>
+                            DRAKVUF Sandbox (C) 2019-2020 <a href="https://cert.pl/">CERT Polska</a><br/>
                             DRAKVUF (C) 2014-2020 <a href="https://tklengyel.com/">Tamas K Lengyel</a>
                         </div>
                         <div className="col-md-6">

--- a/drakcore/setup.py
+++ b/drakcore/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="drakcore",
-    version="0.1.0",
+    version="0.2.0",
     description="DRAKVUF Sandbox Core",
     package_dir={"drakcore": "drakcore"},
     packages=["drakcore"],

--- a/drakrun/debian/changelog
+++ b/drakrun/debian/changelog
@@ -1,3 +1,5 @@
-drakrun (0.1.0) unstable; urgency=low
-  * Initial public release
- -- Michał Leszczyński <ml@icedev.pl>  Tue, 17 Mar 2020 17:00:00 +0100
+drakrun (0.2.0) unstable; urgency=low
+  * New layout in the web UI
+  * Implemented basic networking support
+  * Implemented ZFS support
+ -- Michał Leszczyński <ml@icedev.pl>  Tue, 23 Apr 2020 04:00:00 +0100

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name="drakrun",
-    version="0.1.0",
+    version="0.2.0",
     description="DRAKRUN",
     package_dir={"drakrun": "drakrun"},
     packages=["drakrun"],


### PR DESCRIPTION
* Bump to 0.2.0 before release
* Fix year range for DRAKVUF Sandbox copyright (`2020` -> `2019-2020`)