### PR TITLE
Revert base image back to Debian Buster and make it configurable

### DIFF
--- a/drakcore/package/build.sh
+++ b/drakcore/package/build.sh
@@ -3,13 +3,17 @@
 # Directory with .deb files
 OUTDIR=$(pwd)/out
 # Base image for building
-BASEIMAGE=ubuntu:18.04
+if [ "$BASEIMAGE" = "" ]
+then
+    BASEIMAGE=debian:buster
+fi
+
 # Current user - to make current user owner of output .deb files.
 FILE_OWNER=$(id -u):$(id -g)
 
 echo "Building $BASEIMAGE based image into $OUTDIR"
 docker build -f drakcore/package/Dockerfile \
-	     --build-arg IMAGE=$BASEIMAGE \
+             --build-arg IMAGE=$BASEIMAGE \
              -t deb-build-web . && \
 docker run --rm \
            -it \

--- a/drakrun/package/build.sh
+++ b/drakrun/package/build.sh
@@ -3,7 +3,11 @@
 # Directory with .deb files
 OUTDIR=$(pwd)/out
 # Base image for building
-BASEIMAGE=ubuntu:18.04
+if [ "$BASEIMAGE" = "" ]
+then
+    BASEIMAGE=debian:buster
+fi
+
 # Current user - to make current user owner of output .deb files.
 FILE_OWNER=$(id -u):$(id -g)
 


### PR DESCRIPTION
* revert `BASE_IMAGE` to Debian Buster in both packages
* make it configurable through env variable

Turns out it doesn't actually work cross-distribution :thinking: