### PR TITLE
Add karton-based analysis post processing

### DIFF
--- a/drakcore/debian/drakcore.links
+++ b/drakcore/debian/drakcore.links
@@ -1,3 +1,4 @@
 opt/venvs/drakcore/bin/drak-archiver usr/bin/drak-archiver
 opt/venvs/drakcore/bin/drak-config-setup usr/bin/drak-config-setup
 opt/venvs/drakcore/bin/drak-system usr/bin/drak-system
+opt/venvs/drakcore/bin/drak-postprocess usr/bin/drak-postprocess

--- a/drakcore/debian/postinst
+++ b/drakcore/debian/postinst
@@ -24,3 +24,4 @@ systemctl daemon-reload
 systemctl enable --now drak-system.service
 systemctl enable --now drak-web.service
 systemctl enable --now drak-minio.service
+systemctl enable --now drak-postprocess.service

--- a/drakcore/debian/prerm
+++ b/drakcore/debian/prerm
@@ -16,6 +16,7 @@ case "$1" in
     ;;
 esac
 
+systemctl disable --now drak-postprocess.service
 systemctl disable --now drak-minio.service
 systemctl disable --now drak-system.service
 systemctl disable --now drak-web.service

--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -1,11 +1,10 @@
 import json
 import os
 from tempfile import NamedTemporaryFile
-from io import BytesIO
 
 import requests
 
-from flask import Flask, jsonify, request, send_file, redirect, send_from_directory, Response
+from flask import Flask, jsonify, request, send_file, redirect, send_from_directory, Response, abort
 from karton2 import Config, Producer, Resource, Task
 from minio.error import NoSuchKey
 from datetime import datetime
@@ -13,7 +12,6 @@ from time import mktime
 
 from drakcore.system import SystemService
 from drakcore.util import find_config
-from drakcore.pstree import generate_process_tree
 
 
 app = Flask(__name__, static_folder='frontend/build/static')
@@ -38,11 +36,13 @@ def route_list():
 
     for obj in res:
         try:
-            meta = minio.get_object("drakrun", os.path.join(obj.object_name, "metadata.json"))
+            meta = minio.get_object("drakrun", os.path.join(
+                obj.object_name, "metadata.json"))
         except minio.error.NoSuchKey:
             meta = {}
 
-        analyses.append({"id": obj.object_name.strip('/'), "meta": json.loads(meta.read())})
+        analyses.append({"id": obj.object_name.strip('/'),
+                         "meta": json.loads(meta.read())})
 
     return jsonify(sorted(analyses, key=lambda o: o.get('meta', {}).get('time_finished', 0), reverse=True))
 
@@ -65,40 +65,21 @@ def upload():
     return jsonify({"task_uid": task.uid})
 
 
+@app.route("/processed/<task_uid>/<which>")
+def processed(task_uid, which):
+    try:
+        with NamedTemporaryFile() as f:
+            minio.fget_object("drakrun", f"{task_uid}/{which}.json", f.name)
+            return send_file(f.name, mimetype='application/json')
+    except NoSuchKey:
+        abort(404)
+
+
 @app.route("/logs/<task_uid>/<log_type>")
 def logs(task_uid, log_type):
     with NamedTemporaryFile() as f:
         minio.fget_object("drakrun", task_uid + "/" + log_type + ".log", f.name)
         return send_file(f.name, mimetype='text/plain')
-
-
-def processed_generic(func, obj_name: str, mime: str = "application/json"):
-    def wrapper(task_uid: str):
-        gen_name = f"{task_uid}/processed/{obj_name}"
-        try:
-            # Fast path: object exists
-            with NamedTemporaryFile() as tmp_file:
-                minio.fget_object("drakrun", gen_name, tmp_file.name)
-                return send_file(tmp_file.name, mime)
-        except NoSuchKey:
-            pass
-        # Slow path: generate and upload to minio
-        data = func(minio, task_uid)
-        file = BytesIO(data)
-        minio.put_object("drakrun", gen_name, file, length=len(data))
-        return Response(data, mimetype=mime)
-
-    return wrapper
-
-
-processed_generators = {
-    "process_tree.json": processed_generic(generate_process_tree, "process_tree.json"),
-}
-
-
-@app.route("/processed/<task_uid>/<which>")
-def processed(task_uid, which):
-    return processed_generators[which](task_uid)
 
 
 @app.route("/logs/<task_uid>")

--- a/drakcore/drakcore/bin/drak-postprocess
+++ b/drakcore/drakcore/bin/drak-postprocess
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from drakcore.process import main
+main()

--- a/drakcore/drakcore/frontend/src/api/index.js
+++ b/drakcore/drakcore/frontend/src/api/index.js
@@ -20,7 +20,7 @@ export default {
     return axios.get(`/graph/${analysis}`);
   },
   async getProcessTree(analysis) {
-    return axios.get(`/processed/${analysis}/process_tree.json`);
+    return axios.get(`/processed/${analysis}/process_tree`);
   },
   async query(q) {
     return axios.get("/query", { params: { q: q } });

--- a/drakcore/drakcore/postprocess/__init__.py
+++ b/drakcore/drakcore/postprocess/__init__.py
@@ -1,0 +1,25 @@
+import importlib
+import logging
+import os.path
+from collections import namedtuple
+
+REGISTERED_PLUGINS = []
+
+PostprocessPlugin = namedtuple("PostprocessPlugin", ('required', 'handler'))
+
+
+def postprocess(required=[]):
+    """ Register function as analysis postprocess """
+    def wrapper(func):
+        plugin = PostprocessPlugin(required, func)
+        REGISTERED_PLUGINS.append(plugin)
+    return wrapper
+
+
+fdir = os.path.dirname(__file__)
+for module in os.listdir(fdir):
+    # skip __init__ or __pycache__
+    if module.startswith("__") or not module.endswith(".py"):
+        continue
+    modname = module[:-3]
+    importlib.import_module(f"drakcore.postprocess.{modname}")

--- a/drakcore/drakcore/process.py
+++ b/drakcore/drakcore/process.py
@@ -1,0 +1,45 @@
+import os
+from karton2 import Consumer, Config
+from io import BytesIO
+import json
+from drakcore.postprocess import REGISTERED_PLUGINS
+from drakcore.util import find_config
+from minio.error import NoSuchKey
+
+
+class AnalysisProcessor(Consumer):
+    identity = "karton.drakrun.processor"
+    filters = [{"type": "analysis", "kind": "drakrun"}]
+
+    def __init__(self, config, enabled_plugins):
+        super().__init__(config)
+        if len(enabled_plugins) == 0:
+            raise ValueError("No plugins enabled")
+        self.plugins = enabled_plugins
+
+    def process(self):
+        # downloaded resource cache
+        downloaded_resources = {}
+        for plugin in self.plugins:
+            for resource in plugin.required:
+                if resource in downloaded_resources:
+                    continue
+                try:
+                    remote = self.current_task.get_resource(resource)
+                    local = self.download_resource(remote)
+                    downloaded_resources[resource] = local
+                except NoSuchKey:
+                    self.log.error("Resource not found")
+                    break
+            else:
+                plugin.handler(self.current_task, downloaded_resources, self.minio)
+
+
+def main():
+    conf = Config(find_config())
+    processor = AnalysisProcessor(conf, REGISTERED_PLUGINS)
+    processor.loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/drakcore/drakcore/systemd/drak-postprocess.service
+++ b/drakcore/drakcore/systemd/drak-postprocess.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=drak-postprocess service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/venvs/drakcore/bin/drak-postprocess
+User=root
+Group=root
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+KillSignal=SIGQUIT
+WorkingDirectory=/var/lib/drakcore
+
+[Install]
+WantedBy=default.target

--- a/drakcore/drakcore/tests/test_process_tree.py
+++ b/drakcore/drakcore/tests/test_process_tree.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from drakcore.pstree import ProcessTree
+from drakcore.postprocess.pstree import ProcessTree
 
 
 def test_empty_tree():

--- a/drakcore/setup.py
+++ b/drakcore/setup.py
@@ -10,10 +10,10 @@ setup(
     version="0.2.0",
     description="DRAKVUF Sandbox Core",
     package_dir={"drakcore": "drakcore"},
-    packages=["drakcore"],
+    packages=["drakcore", "drakcore.postprocess"],
     include_package_data=True,
     install_requires=open("requirements.txt").read().splitlines(),
-    scripts=['drakcore/bin/drak-archiver', 'drakcore/bin/drak-system', 'drakcore/bin/drak-config-setup'],
+    scripts=['drakcore/bin/drak-archiver', 'drakcore/bin/drak-system', 'drakcore/bin/drak-config-setup', 'drakcore/bin/drak-postprocess'],
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -17,6 +17,7 @@ def test_services_running(drakmon_vm):
         get_service_info(drakmon_vm, "drak-system.service"),
         get_service_info(drakmon_vm, "drak-minio.service"),
         get_service_info(drakmon_vm, "drak-web.service"),
+        get_service_info(drakmon_vm, "drak-postprocess.service"),
         get_service_info(drakmon_vm, "redis-server.service"),
     )
 


### PR DESCRIPTION
closes #71 

Moved the post processing into drakrun as karton Consumer.
The only thing left is to decide how we would like to run it. By adding another daemon? :thinking: 
