### PR TITLE
Bump default disk size to 100 GB

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -393,7 +393,7 @@ def main():
     install_p = subparsers.add_parser('install', help='Install guest Virtual Machine')
     install_p.set_defaults(which='install')
     install_p.add_argument('--storage-backend', default='qcow2', type=str, help='Storage backend (default: qcow2)')
-    install_p.add_argument('--disk-size', default='20G', type=str, help='Disk size (default: 20G)')
+    install_p.add_argument('--disk-size', default='100G', type=str, help='Disk size (default: 100G)')
     install_p.add_argument('--zfs-tank-name', type=str, help='Tank name (only for zfs storage backend)')
     install_p.add_argument('--max-vms', default=1, type=str, help='Maximum number of simultaneous VMs (default: 1)')
     install_p.add_argument('--iso', type=str, help='Installation ISO', required=True)


### PR DESCRIPTION
Looks like some drivers are not properly installed in Windows 10 when there is low disk space. We use either qcow2 or zfs which both can overbook space so there is no problem with disk being virtually large though.