### PR TITLE
Fix exception handling in /list endpoint

### DIFF
--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -38,7 +38,7 @@ def route_list():
         try:
             meta = minio.get_object("drakrun", os.path.join(
                 obj.object_name, "metadata.json"))
-        except minio.error.NoSuchKey:
+        except NoSuchKey:
             meta = {}
 
         analyses.append({"id": obj.object_name.strip('/'),


### PR DESCRIPTION
When [analysis]/metadata.json object is missing, /list endpoint will
fail due to incorrect handling of exception.

The code tries to use minio.error.NoSuchKey exception, however the
exception object is imported as NoSuchKey and minio refers to Minio
client object.

closes #144 