### PR TITLE
drakrun/configs: Fix running Windows with nested KVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ In order to run DRAKVUF Sandbox, your setup must fullfill all of the listed requ
 
 Nested virtualization:
 
-* KVM, Hyper-v are **not** supported
-* because of the above, hosting drakvuf-sandbox in cloud is also **not** supported (because most hosting providers use one of the above)
-* however, nested Xen **does** work
+* KVM **does** work, however it is considered experimental. If you experience any bugs, please report them to us for further investigation.
+* Due to lack of exposed CPU features, hosting drakvuf-sandbox in cloud is **not** supported (although it might change in the future)
+* Hyper-V does **not** work
+* Xen **does** work out of the box
 * VMware Workstation Player **does** work, but you need to check Virtualize EPT option for a VM; Intel processor with EPT still required
 
 ### Basic installation

--- a/drakrun/drakrun/scripts/cfg.template
+++ b/drakrun/drakrun/scripts/cfg.template
@@ -21,5 +21,7 @@ altp2m = 2
 shadow_memory = 16
 audio=1
 soundhw='hda'
+cpuid="host,htt=0"
+vga="stdvga"
 vif = [ 'type=ioemu,model=e1000,bridge=drak{{ VM_ID }}' ]
 disk = [ {{ DISKS }} ]


### PR DESCRIPTION
OK, so after a lot of debugging we have to add two lines in VM configuration file.
CPUID one disables hyperthreading support flag and VGA changes driver from cirrus to stdvga which is currently recommended by QEMU developers.

closes #149 