### PR TITLE
storage: ZFS: Use sparse vm-0 volume

### DIFF
--- a/drakrun/drakrun/storage.py
+++ b/drakrun/drakrun/storage.py
@@ -90,6 +90,7 @@ class ZfsStorageBackend(StorageBackendBase):
                     [
                         "zfs",
                         "create",
+                        "-s",
                         "-V",
                         shlex.quote(disk_size),
                         shlex.quote(os.path.join(self.zfs_tank_name, "vm-0")),


### PR DESCRIPTION
We can overprovision ZFS block device to present large disk to Windows and use smaller disk under the hood