### PR TITLE
Sample hash in AnalysisMain view

### DIFF
--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -134,6 +134,13 @@ def graph(task_uid):
         return send_file(f.name, mimetype='text/plain')
 
 
+@app.route("/sha256/<task_uid>")
+def sha256(task_uid):
+    with NamedTemporaryFile() as f:
+        minio.fget_object("drakrun", f"{task_uid}/sample_sha256.txt", f.name)
+        return send_file(f.name, mimetype='text/plain')
+
+
 @app.route("/status/<task_uid>")
 def status(task_uid):
     tasks = rs.keys("karton.task:*")

--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -134,11 +134,11 @@ def graph(task_uid):
         return send_file(f.name, mimetype='text/plain')
 
 
-@app.route("/sha256/<task_uid>")
-def sha256(task_uid):
-    with NamedTemporaryFile() as f:
-        minio.fget_object("drakrun", f"{task_uid}/sample_sha256.txt", f.name)
-        return send_file(f.name, mimetype='text/plain')
+@app.route("/metadata/<task_uid>")
+def metadata(task_uid):
+    tmp = minio.get_object("drakrun", f"{task_uid}/metadata.json")
+    meta = json.loads(tmp.read())
+    return jsonify(meta)
 
 
 @app.route("/status/<task_uid>")

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -144,7 +144,7 @@ class AnalysisMain extends Component {
       graph: null,
       graphState: "loading",
       processTree: null,
-      sha256: null
+      sha256: null,
     };
 
     this.analysisID = this.props.match.params.analysis;

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -21,10 +21,7 @@ function computeExpandState(expandPid, process, expandMap) {
 }
 
 function formatTimestamp(ts) {
-  return new Date(ts * 1000)
-    .toISOString()
-    .replace("T", " ")
-    .split(".")[0];
+  return new Date(ts * 1000).toISOString().replace("T", " ").split(".")[0];
 }
 
 class ProcessTree extends Component {

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -20,6 +20,13 @@ function computeExpandState(expandPid, process, expandMap) {
   expandMap[process.pid] = childrenExpanded || process.pid === expandPid;
 }
 
+function formatTimestamp(ts) {
+  return new Date(ts * 1000)
+    .toISOString()
+    .replace("T", " ")
+    .replace(".000Z", "");
+}
+
 class ProcessTree extends Component {
   constructor(props) {
     super(props);
@@ -144,7 +151,7 @@ class AnalysisMain extends Component {
       graph: null,
       graphState: "loading",
       processTree: null,
-      sha256: null,
+      metadata: null,
     };
 
     this.analysisID = this.props.match.params.analysis;
@@ -174,9 +181,9 @@ class AnalysisMain extends Component {
       this.setState({ processTree: process_tree.data, injectedPid });
     }
 
-    const sha256 = await api.getSha256(this.analysisID);
-    if (sha256.data) {
-      this.setState({ sha256: sha256.data });
+    const metadata = await api.getMetadata(this.analysisID);
+    if (metadata.data) {
+      this.setState({ metadata: metadata.data });
     }
   }
 
@@ -226,6 +233,38 @@ class AnalysisMain extends Component {
       );
     }
 
+    let metadata;
+    if (this.state.metadata) {
+      metadata = (
+        <div background>
+          <table className="table table-striped table-bordered">
+            <tbody>
+              <tr>
+                <td>Sha256</td>
+                <td>{this.state.metadata.sample_sha256}</td>
+              </tr>
+              <tr>
+                <td>Magic bytes</td>
+                <td>{this.state.metadata.magic_output}</td>
+              </tr>
+              <tr>
+                <td>Start command</td>
+                <td>{this.state.metadata.start_command}</td>
+              </tr>
+              <tr>
+                <td>Started at</td>
+                <td>{formatTimestamp(this.state.metadata.time_started)}</td>
+              </tr>
+              <tr>
+                <td>Finished at</td>
+                <td>{formatTimestamp(this.state.metadata.time_finished)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
     return (
       <div className="App container-fluid">
         <div className="page-title-box">
@@ -234,8 +273,9 @@ class AnalysisMain extends Component {
 
         <div className="card tilebox-one">
           <div className="card-body">
-            <h5 className="card-title mb-0">Sha256</h5>
-            {this.state.sha256}
+            <h5 className="card-title mb-0">Metadata</h5>
+
+            {metadata}
           </div>
         </div>
 

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -144,6 +144,7 @@ class AnalysisMain extends Component {
       graph: null,
       graphState: "loading",
       processTree: null,
+      sha256: null
     };
 
     this.analysisID = this.props.match.params.analysis;
@@ -171,6 +172,11 @@ class AnalysisMain extends Component {
     if (process_tree && inject_log) {
       const injectedPid = inject_log.data["InjectedPid"];
       this.setState({ processTree: process_tree.data, injectedPid });
+    }
+
+    const sha256 = await api.getSha256(this.analysisID);
+    if (sha256.data) {
+      this.setState({ sha256: sha256.data });
     }
   }
 
@@ -224,6 +230,13 @@ class AnalysisMain extends Component {
       <div className="App container-fluid">
         <div className="page-title-box">
           <h4 className="page-title">Report</h4>
+        </div>
+
+        <div className="card tilebox-one">
+          <div className="card-body">
+            <h5 className="card-title mb-0">Sha256</h5>
+            {this.state.sha256}
+          </div>
         </div>
 
         <div className="card tilebox-one">

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -24,7 +24,7 @@ function formatTimestamp(ts) {
   return new Date(ts * 1000)
     .toISOString()
     .replace("T", " ")
-    .replace(".000Z", "");
+    .split(".")[0];
 }
 
 class ProcessTree extends Component {

--- a/drakcore/drakcore/frontend/src/api/index.js
+++ b/drakcore/drakcore/frontend/src/api/index.js
@@ -13,8 +13,8 @@ export default {
   async listLogs(analysis) {
     return axios.get(`/logs/${analysis}`);
   },
-  async getSha256(analysis) {
-    return axios.get(`/sha256/${analysis}`);
+  async getMetadata(analysis) {
+    return axios.get(`/metadata/${analysis}`);
   },
   async getStatus(analysis) {
     return axios.get(`/status/${analysis}`);

--- a/drakcore/drakcore/frontend/src/api/index.js
+++ b/drakcore/drakcore/frontend/src/api/index.js
@@ -13,6 +13,9 @@ export default {
   async listLogs(analysis) {
     return axios.get(`/logs/${analysis}`);
   },
+  async getSha256(analysis) {
+    return axios.get(`/sha256/${analysis}`);
+  },
   async getStatus(analysis) {
     return axios.get(`/status/${analysis}`);
   },


### PR DESCRIPTION
![Screenshot from 2020-08-05 12-25-21](https://user-images.githubusercontent.com/26001306/89402774-a626c600-d717-11ea-8dc1-646d3d35c6ec.png)


I believe it's nice to have sample hash visible in AnalysisMain view. I will be happy to change the position of this component if our user experience team decides so.