### PR TITLE
Change dh-virtualenv to debian-built version

### DIFF
--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \
     pip3 install virtualenv && \
-    apt install -y ./dh-virtualenv.deb
+    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 COPY drakcore /build
 WORKDIR /build

--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
-    curl "https://debs.icedev.pl/manual/dh-virtualenv/$(lsb_release -cs)/dh-virtualenv_1.2~dev-1_all.deb" -o dh-virtualenv.deb && \
+    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     wget curl python3 python3-pip debhelper devscripts \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
-    curl "https://debs.icedev.pl/manual/dh-virtualenv/$(lsb_release -cs)/dh-virtualenv_1.2~dev-1_all.deb" -o dh-virtualenv.deb && \
+    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     pip3 install virtualenv==20.0.23 && \
     apt install -y ./dh-virtualenv.deb
 

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
     curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     pip3 install virtualenv==20.0.23 && \
-    apt install -y ./dh-virtualenv.deb
+    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 RUN wget -O drakvuf.deb "https://debs.icedev.pl/manual/drakvuf-bundle/$(lsb_release -cs)/drakvuf-bundle-0.7-git20200501075508+0f828ce-1.deb" && \
     apt install -y ./drakvuf.deb

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 RUN wget -O drakvuf.deb "https://debs.icedev.pl/manual/drakvuf-bundle/$(lsb_release -cs)/drakvuf-bundle-0.7-git20200501075508+0f828ce-1.deb" && \
-    apt install -y ./drakvuf.deb
+    dpkg -i ./drakvuf.deb
 
 COPY drakrun /build
 WORKDIR /build

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
-    wget curl python3 python3-pip debhelper devscripts \
+    wget curl python3 python3-pip python3-venv debhelper devscripts \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
     curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y \
     wget curl python3 python3-pip debhelper devscripts \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
-    if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
+    if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
     curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     pip3 install virtualenv==20.0.23 && \
     dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb


### PR DESCRIPTION
Ok, so release 1.2.1 of dh-virtualenv is already in Debian repositories, so we may use it.

(TODO: test ubuntu 18/20 before merging)