### PR TITLE
Use click for draksetup CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This instruction assumes that you want to create a single-node installation with
    ```
 4. Execute:
    ```
-   # draksetup install --iso /opt/path_to_windows.iso
+   # draksetup install /opt/path_to_windows.iso
    ```
    carefully read the command's output. This command would run a Virtual Machine with Windows system installation process.
    

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -265,9 +265,13 @@ def create_rekall_profiles(install_info: InstallInfo):
 
 
 @click.command()
-@click.option('--report/--no-report', default=True,
+@click.option('--report/--no-report',
+              default=True,
+              show_default=True,
               help="Send anonymous usage report")
-@click.option('--usermode/--no-usermode', default=False,
+@click.option('--usermode/--no-usermode',
+              default=True,
+              show_default=True,
               help="Generate user mode profiles")
 def postinstall(report, generate_usermode):
     if os.path.exists(os.path.join(ETC_DIR, "no_usage_reports")):

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -6,3 +6,4 @@ requests==2.22.0
 tqdm==4.43.0
 python-magic==0.4.15
 dataclasses-json==0.5.1
+click==7.1.2


### PR DESCRIPTION
`click` provides cleaner approach for building CLIs :)
One breaking change:
```
draksetup install [ISO_PATH]
```
instead of 
```
draksetup install --iso
```
 providing ISO file is mandatory so we might as well parse it as an argument to the command