### PR TITLE
Store drakrun/drak-postprocess logs in Minio

### DIFF
--- a/drakcore/drakcore/process.py
+++ b/drakcore/drakcore/process.py
@@ -1,10 +1,64 @@
 import os
-from karton2 import Consumer, Config
-from io import BytesIO
+import logging
 import json
+import functools
+from io import StringIO
+
+from karton2 import Consumer, Config, Karton, LocalResource
+from minio.error import NoSuchKey
 from drakcore.postprocess import REGISTERED_PLUGINS
 from drakcore.util import find_config
-from minio.error import NoSuchKey
+
+
+class LocalLogBuffer(logging.Handler):
+    FIELDS = (
+        "levelname",
+        "message",
+        "created",
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.buffer = []
+
+    def emit(self, record):
+        entry = {k: v for (k, v) in record.__dict__.items() if k in self.FIELDS}
+        self.buffer.append(entry)
+
+
+# TODO: Deduplicate this, once we have shared code between drakcore and drakrun
+def with_logs(object_name):
+    def decorator(method):
+        @functools.wraps(method)
+        def wrapper(self: Karton, *args, **kwargs):
+            handler = LocalLogBuffer()
+            try:
+                # Register new log handler
+                self.log.addHandler(handler)
+                method(self, *args, **kwargs)
+            except Exception:
+                self.log.exception("Analysis failed")
+            finally:
+                # Unregister local handler
+                self.log.removeHandler(handler)
+                try:
+                    buffer = StringIO()
+                    for idx, entry in enumerate(handler.buffer):
+                        if idx > 0:
+                            buffer.write("\n")
+                        buffer.write(json.dumps(entry))
+
+                    res = LocalResource(object_name,
+                                        buffer.getvalue(),
+                                        bucket="drakrun")
+                    task_uid = self.current_task.payload.get('analysis_uid') or self.current_task.uid
+                    res._uid = f"{task_uid}/{res.name}"
+                    res.upload(self.minio)
+                except Exception:
+                    self.log.exception("Failed to upload analysis logs")
+        return wrapper
+
+    return decorator
 
 
 class AnalysisProcessor(Consumer):
@@ -17,22 +71,21 @@ class AnalysisProcessor(Consumer):
             raise ValueError("No plugins enabled")
         self.plugins = enabled_plugins
 
+    @with_logs('drak-postprocess.log')
     def process(self):
         # downloaded resource cache
-        task_resources = {}
+        task_resources = dict(self.current_task.iterate_resources())
         for plugin in self.plugins:
-            for resource in plugin.required:
-                if resource in task_resources:
-                    continue
-                r = self.current_task.get_resource(resource)
-                if r is None:
-                    break
-                task_resources[resource] = r
-            else:
-                try:
-                    plugin.handler(self.current_task, task_resources, self.minio)
-                except Exception as e:
-                    self.log.error("%s", e)
+            name = plugin.handler.__name__
+            if any(map(lambda r: r not in task_resources.keys(), plugin.required)):
+                self.log.info("Skipping %s, missing resources", name)
+                continue
+
+            try:
+                self.log.info("Running postprocess - %s", plugin.handler.__name__)
+                plugin.handler(self.current_task, task_resources, self.minio)
+            except Exception:
+                self.log.error("Postprocess failed", exc_info=True)
 
 
 def main():


### PR DESCRIPTION
This patch adds drakrun and drak-postprocess logs for each analysis
in Minio. This allows for easier debugging as the logs can be viewed
directly in browser instead of SSHing into the server.

Currently, we have no shared code between drakrun and drakcore so some
of the changes are duplicated.