### PR TITLE
Fix invalid argument in draksetup postinstall

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -269,7 +269,7 @@ def create_rekall_profiles(install_info: InstallInfo):
               default=True,
               show_default=True,
               help="Send anonymous usage report")
-@click.option('--usermode/--no-usermode',
+@click.option('--usermode/--no-usermode', 'generate_usermode',
               default=True,
               show_default=True,
               help="Generate user mode profiles")


### PR DESCRIPTION
Should fix:

```
# draksetup postinstall
Traceback (most recent call last):
  File "/root/drakvuf-sandbox/venv/bin/draksetup", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/root/drakvuf-sandbox/drakrun/drakrun/py-scripts/draksetup", line 5, in <module>
    ds.main()
  File "/root/drakvuf-sandbox/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/root/drakvuf-sandbox/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/root/drakvuf-sandbox/venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/drakvuf-sandbox/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/drakvuf-sandbox/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
TypeError: postinstall() got an unexpected keyword argument 'usermode'
```