### PR TITLE
Implement mount command in draksetup

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -423,6 +423,18 @@ def postupgrade():
     detect_defaults()
 
 
+@click.command()
+@click.argument('domain',
+    type=str)
+@click.argument('iso_path',
+    type=click.Path(exists=True))
+def mount(domain, iso_path):
+    '''Inject ISO file into specified guest vm.
+    Domain can be retrieved by running "xl list" command on the host.
+    '''
+    subprocess.run(['xl', 'qemu-monitor-command', domain, f'change ide-5632 {iso_path}'])
+
+
 @click.group()
 def main():
     pass
@@ -431,6 +443,8 @@ def main():
 main.add_command(install)
 main.add_command(postinstall)
 main.add_command(postupgrade)
+main.add_command(mount)
+
 
 if __name__ == "__main__":
     if os.geteuid() != 0:

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -226,7 +226,7 @@ def send_usage_report(report):
 def create_rekall_profiles(install_info: InstallInfo):
     storage_backend = get_storage_backend(install_info)
     with storage_backend.vm0_root_as_block() as block_device, \
-         tempfile.TemporaryDirectory() as mount_path:
+            tempfile.TemporaryDirectory() as mount_path:
         mnt_path_quoted = shlex.quote(mount_path)
         blk_quoted = shlex.quote(block_device)
         try:
@@ -424,10 +424,8 @@ def postupgrade():
 
 
 @click.command()
-@click.argument('domain',
-    type=str)
-@click.argument('iso_path',
-    type=click.Path(exists=True))
+@click.argument('domain', type=str)
+@click.argument('iso_path', type=click.Path(exists=True))
 def mount(domain, iso_path):
     '''Inject ISO file into specified guest vm.
     Domain can be retrieved by running "xl list" command on the host.


### PR DESCRIPTION
Added wrapper over complex `xl qemu-monitor-command change` instruction.

Issue: #171 

I couldn't find information regarding the device number. We rely on hard coded `5632` index. Is that ok, or should be parse output of: `xl qemu-monitor-command "info block"`?
The example output of `info block`:
```bash
$ xl qemu-monitor-command vm-1 "info block"
ide0-hd0 (#block191): /home/k/dev/var/lib/drakrun/volumes/vm-1.img (qcow2)
    Attached to:      /machine/unattached/device[13]
    Cache mode:       writeback
    Backing file:     /var/lib/drakrun/volumes/vm-0.img (chain depth: 1)

ide-5632 (#block530): /home/k/dev/drakvuf-packages/win-iso/SW_DVD5_Win_Pro_7w_SP1_64BIT_Polish_-2_MLF_X17-59386.ISO (raw, read-only)
    Attached to:      /machine/unattached/device[14]
    Removable device: not locked, tray closed
    Cache mode:       writeback

ide-5696 (#block743): /home/k/dev/var/lib/drakrun//volumes/unattended.iso (raw, read-only)
    Attached to:      /machine/unattached/device[15]
    Removable device: not locked, tray closed
    Cache mode:       writeback
```

