### PR TITLE
More liberal regex check for uploaded filenames

### DIFF
--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -1,6 +1,7 @@
 import json
 import os
 from tempfile import NamedTemporaryFile
+import re
 
 import requests
 import logging
@@ -71,6 +72,9 @@ def upload():
         filename = request.form.get("file_name")
     else:
         filename = request.files['file'].filename
+    if not re.fullmatch(r'^((?![\\/><|:&])[\x20-\xfe])+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$',
+                        filename, flags=re.IGNORECASE):
+        return jsonify({"error": "invalid file_name"}), 400
     task.add_payload("file_name", os.path.splitext(filename)[0])
 
     # Extract and add extension

--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -103,16 +103,12 @@ class UploadSample extends Component {
     const fname = hasCustomFileName
       ? this.state.customFileName
       : this.state.file.name;
-    // Check for whitespace
-    if (!fname.match(/^\S+$/)) {
-      errMsg = "File name contains invalid characters";
-    } else if (
-      !fname.match(
-        /^[\w\-.]+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$/i
+    if (!fname.match(
+        /^((?![\\/><|:&])[\x20-\xfe])+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$/i
       )
     ) {
       errMsg =
-        "Invalid file name. Only .dll, .exe and office files are supported";
+        "File name should not contain special characters. Moreover only .dll, .exe and office files are supported.";
     }
 
     if (hasCustomStartCmd) {

--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -108,7 +108,7 @@ class UploadSample extends Component {
       errMsg = "File name contains invalid characters";
     } else if (
       !fname.match(
-        /^[\w]+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$/i
+        /^[\w\-.]+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$/i
       )
     ) {
       errMsg =

--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -103,7 +103,8 @@ class UploadSample extends Component {
     const fname = hasCustomFileName
       ? this.state.customFileName
       : this.state.file.name;
-    if (!fname.match(
+    if (
+      !fname.match(
         /^((?![\\/><|:&])[\x20-\xfe])+\.(?:dll|exe|doc|docm|docx|dotm|xls|xlsx|xlsm|xltx|xltm)$/i
       )
     ) {


### PR DESCRIPTION
Solves:  #237 
It's now possible to upload files with filenames containing dots and dashes. For example: `invoice.pdf.exe`, `sample-1.exe`.

