### PR TITLE
Update VM config template

### DIFF
--- a/drakrun/drakrun/scripts/cfg.template
+++ b/drakrun/drakrun/scripts/cfg.template
@@ -4,7 +4,7 @@ maxmem = 3048
 memory = 3048
 vcpus = 2
 maxvcpus = 2
-builder = "hvm"
+type = "hvm"
 boot = "cd,menu=on,splash=/usr/share/drakrun/splash.jpg,splash-time=2000"
 hap = 1
 acpi = 1


### PR DESCRIPTION
Guest option 'builder' is deprecated. Replace it with 'type'.

See:
https://xenbits.xen.org/docs/4.14-testing/man/xl.cfg.5.html#Deprecated-guest-type-selection