### PR TITLE
Integrate drakvuf-bundle building with CI infrastracture

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -110,6 +110,40 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: build-drakvuf-bundle
+
+steps:
+- name: package drakvuf-bundle
+  image: debian:buster
+  commands:
+    # Install dependencies
+    - export DEBIAN_FRONTEND=noninteractive
+    - apt-get update && apt-get install -y -q git wget
+    # Configure Minio
+    - wget -q -O /usr/local/bin/mc http://192.168.21.1:5000/static/mc
+    - chmod +x /usr/local/bin/mc
+    - mc config host add cache http://192.168.21.131:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+    - mc mb --ignore-existing cache/debs
+    # Checkout submodules
+    - git submodule update --init --recursive
+    - export DRAKVUF_COMMIT=$(git ls-tree HEAD drakvuf | awk '{ print $3 }')
+    # Build drakvuf-bundle
+    - sh drakvuf/package/depends.sh
+    - bash ci/build_bundle.sh
+  environment:
+    MINIO_ACCESS_KEY:
+      from_secret: MINIO_ACCESS_KEY
+    MINIO_SECRET_KEY:
+      from_secret: MINIO_SECRET_KEY
+node:
+   purpose: generic
+trigger:
+  event:
+    exclude:
+    - pull_request
+---
+kind: pipeline
+type: docker
 name: test-e2e
 
 steps:

--- a/ci/build_bundle.sh
+++ b/ci/build_bundle.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+INSTALL_PATH=/build/usr
+mkdir -p $INSTALL_PATH
+
+mc stat cache/debs/drakvuf-bundle-${DRAKVUF_COMMIT}.deb
+if [ $? -eq 0 ]; then
+    echo "Package already exists. Skipping..."
+    exit 0
+fi
+
+set -e
+
+# Build Xen
+pushd drakvuf/xen
+
+./configure --prefix=/usr --enable-githttp --disable-pvshim > /dev/null 2>&1
+make -j$(nproc) dist > /dev/null 2>&1
+echo "Running Xen's make install-xen..."
+make -j$(nproc) install-xen
+echo "Running Xen's make install-tools..."
+make -j$(nproc) install-tools
+
+mv dist/install /dist-xen
+popd
+# Build DRAKVUF
+mkdir -p drakvuf/libvmi/build
+
+# Build LibVMI
+pushd drakvuf/libvmi/build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
+         -DENABLE_FILE=OFF \
+         -DENABLE_LINUX=OFF \
+         -DENABLE_FREEBSD=OFF \
+         -DENABLE_KVM=OFF \
+         -DENABLE_BAREFLANK=OFF
+make -j$(nproc)
+make install
+ldconfig
+popd
+
+# Package DRAKVUF and Xen
+pushd drakvuf
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$INSTALL_PATH/lib" && \
+export C_INCLUDE_PATH="$INSTALL_PATH/include" && \
+export CPLUS_INCLUDE_PATH="$INSTALL_PATH/include" && \
+export PKG_CONFIG_PATH="$INSTALL_PATH/lib/pkgconfig/" && \
+export LDFLAGS="-L$INSTALL_PATH/lib" && \
+export CFLAGS="-I$INSTALL_PATH/include" && \
+autoreconf -vif
+./configure --prefix=$INSTALL_PATH --enable-debug
+make -j$(nproc)
+make install
+
+mkdir /out
+sh ./package/mkdeb
+popd
+
+
+mc cp /out/drakvuf-bundle*.deb "cache/debs/drakvuf-bundle-$DRAKVUF_COMMIT.deb"


### PR DESCRIPTION
We're relying on externally hosted debs of drakvuf-bundle. This patch
intergates the build process with our CI. This ensures that updated
drakvuf submodule can be built correctly and enables further
enhancements in the future.