### PR TITLE
ci: Build Debian-based images with preinstalled drakvuf-bundle

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -207,3 +207,44 @@ trigger:
   event:
     exclude:
     - pull_request
+---
+kind: pipeline
+type: docker
+name: build-base-image
+
+steps:
+- name: get DRAKVUF commit
+  image: alpine/git
+  commands:
+      - git submodule update --init --recursive
+      - export DRAKVUF_COMMIT=$(git ls-tree HEAD drakvuf | awk '{ print $3 }')
+      - echo "$DRAKVUF_COMMIT" > drakvuf_commit.txt
+- name: get mc
+  image: minio/mc
+  commands:
+      # Get mc binary for next step
+      - cp $(which mc) .
+- name: build VM
+  image: hashicorp/packer:light
+  commands:
+      - mv mc /bin
+      - mc config host add cache "$MINIO_SERVER" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+      - mc mb --ignore-existing cache/images
+      - export DRAKVUF_COMMIT=$(cat drakvuf_commit.txt)
+      - apk add qemu-system-x86_64 qemu-img
+      - cd ci/packer
+      - sh build_vm.sh
+  environment:
+    MINIO_ACCESS_KEY:
+      from_secret: MINIO_ACCESS_KEY
+    MINIO_SECRET_KEY:
+      from_secret: MINIO_SECRET_KEY
+    MINIO_SERVER: http://192.168.21.131:9000
+node:
+   purpose: generic
+depends_on:
+- build-drakvuf-bundle
+trigger:
+  event:
+    exclude:
+    - pull_request

--- a/ci/packer/.gitignore
+++ b/ci/packer/.gitignore
@@ -1,0 +1,2 @@
+packer_cache/
+*.iso

--- a/ci/packer/build_vm.sh
+++ b/ci/packer/build_vm.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+mc stat cache/images/drak-ci-${DRAKVUF_COMMIT}.qcow2
+if [ $? -eq 0 ]; then
+    echo "Image already exists. Skipping..."
+    exit 0
+fi
+
+set -e
+
+packer build -var bundle_url=$MINIO_SERVER/debs/drakvuf-bundle-${DRAKVUF_COMMIT}.deb vmbase.json
+qemu-img resize debian_base/drak-ci +50G
+
+mc cp debian_base/drak-ci cache/images/drak-ci-${DRAKVUF_COMMIT}.qcow2
+

--- a/ci/packer/install_zfs.sh
+++ b/ci/packer/install_zfs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+cat <<EOF >> /etc/apt/sources.list.d/buster-backports.list
+deb http://deb.debian.org/debian buster-backports main contrib
+deb-src http://deb.debian.org/debian buster-backports main contrib
+EOF
+
+cat <<EOF >> /etc/apt/preferences.d/90_zfs
+Package: libnvpair1linux libuutil1linux libzfs2linux libzpool2linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
+Pin: release n=buster-backports
+Pin-Priority: 990
+EOF
+
+apt-get update
+apt-get install -y dpkg-dev linux-headers-$(uname -r) linux-image-amd64
+apt-get install -y zfs-dkms zfsutils-linux

--- a/ci/packer/preseed.cfg
+++ b/ci/packer/preseed.cfg
@@ -1,0 +1,78 @@
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# Don't ask for additional CD-ROMS
+d-i apt-setup/cdrom/set-first boolean false
+d-i apt-setup/cdrom/set-next boolean false
+d-i apt-setup/cdrom/set-failed boolean false
+
+# Keyboard selection.
+d-i keyboard-configuration/xkb-keymap select us
+# d-i keyboard-configuration/toggle select No toggling
+
+# netcfg will choose an interface that has link if possible. This makes it
+# skip displaying a list if there is more than one interface.
+d-i netcfg/choose_interface select auto
+
+# Disable that annoying WEP key dialog.
+d-i netcfg/wireless_wep string
+
+# Choose sane mirror
+d-i mirror/country string manual
+d-i mirror/http/hostname string httpredir.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+# Skip creation of a normal user account.
+d-i passwd/make-user boolean false
+
+# Setup root account
+d-i passwd/root-password password root
+d-i passwd/root-password-again password root
+
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string US/Eastern
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+
+# - regular: use the usual partition types for your architecture
+d-i partman-auto/method string regular
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+### Package selection
+tasksel tasksel/first multiselect standard, ssh-server
+
+popularity-contest popularity-contest/participate boolean false
+
+# This is fairly safe to set, it makes grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the MBR if it also finds some other
+# OS, which is less safe as it might not be able to boot that other OS.
+d-i grub-installer/with_other_os boolean true
+
+# Due notably to potential USB sticks, the location of the MBR can not be
+# determined safely in general, so this needs to be specified:
+d-i grub-installer/bootdev  string default
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+d-i preseed/late_command string \
+  in-target sed -i 's/^.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config

--- a/ci/packer/vmbase.json
+++ b/ci/packer/vmbase.json
@@ -1,0 +1,41 @@
+{
+  "builders": [
+    {
+      "type": "qemu",
+      "iso_urls": [
+        "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.6.0-amd64-netinst.iso"
+      ],
+      "boot_command": [
+        "<esc><wait>",
+        "install <wait>",
+        "auto=true <wait>",
+        "netcfg/get_hostname={{ .Name }} <wait>",
+        "netcfg/get_domain=foo <wait>",
+        "debconf/frontend=noninteractive <wait>",
+        "url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "<enter><wait>"
+      ],
+      "iso_checksum": "sha256:2af8f43d4a7ab852151a7f630ba596572213e17d3579400b5648eba4cc974ed0",
+      "output_directory": "debian_base",
+      "http_directory": ".",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": "5000M",
+      "cpus": 2,
+      "memory": 1024,
+      "format": "qcow2",
+      "ssh_username": "root",
+      "ssh_password": "root",
+      "ssh_timeout": "40m",
+      "vm_name": "drak-ci",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "10s",
+      "headless": true
+    }
+  ],
+  "provisioners": [
+      { "type": "shell", "script": "install_zfs.sh" },
+      { "type": "shell", "inline": ["wget -q {{user `bundle_url`}} -O drakvuf-bundle.deb", "apt-get install -y ./drakvuf-bundle.deb", "rm drakvuf-bundle.deb"] },
+      { "type": "shell", "inline": ["export DRAK_DOM0_CPU=1", "export DRAK_DOM0_RAM=2048", "update-grub"] }
+  ]
+}


### PR DESCRIPTION
closes #107

Some additional plumbing is required to use the image during testing, this might come in further PR.