### PR TITLE
Fix bug in AnalysisList.js

### DIFF
--- a/drakcore/drakcore/frontend/src/AnalysisList.js
+++ b/drakcore/drakcore/frontend/src/AnalysisList.js
@@ -20,7 +20,7 @@ class AnalysisList extends Component {
 
   formatTimestamp(ts) {
     if (!ts) {
-        return "-";
+      return "-";
     }
 
     return new Date(ts * 1000)

--- a/drakcore/drakcore/frontend/src/AnalysisList.js
+++ b/drakcore/drakcore/frontend/src/AnalysisList.js
@@ -19,6 +19,10 @@ class AnalysisList extends Component {
   }
 
   formatTimestamp(ts) {
+    if (!ts) {
+        return "-";
+    }
+
     return new Date(ts * 1000)
       .toISOString()
       .replace("T", " ")


### PR DESCRIPTION
In some circumstances, the analysis bucket might contain invalid/corrupted/missing data. This shouldn't break analysis list completely (now: it does).

When there is any folder with missing metadata in the analysis result bucket:
```
Uncaught (in promise) RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at a.value (AnalysisList.js:23)
    at AnalysisList.js:56
    at Array.map (<anonymous>)
    at a.value (AnalysisList.js:47)
    at Fa (react-dom.production.min.js:182)
    at Xa (react-dom.production.min.js:181)
    at df (react-dom.production.min.js:263)
    at ol (react-dom.production.min.js:246)
    at fl (react-dom.production.min.js:246)
```