### PR TITLE
drakcore: don't display broken analyses in the web UI

### DIFF
--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -42,7 +42,7 @@ def route_list():
             tmp = minio.get_object("drakrun", os.path.join(obj.object_name, "metadata.json"))
             meta = json.loads(tmp.read())
         except NoSuchKey:
-            meta = {}
+            continue
 
         analyses.append({"id": obj.object_name.strip('/'), "meta": meta})
 


### PR DESCRIPTION
resolve #266

Avoid returning half-empty objects from drak-web backend's `/list` endpoint, so we don't have glitchy entries in the analysis list UI.