### PR TITLE
draksetup mount: allow to use non-absolute path, default to vm-0

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -424,14 +424,21 @@ def postupgrade():
     detect_defaults()
 
 
-@click.command()
-@click.argument('domain', type=str)
-@click.argument('iso_path', type=click.Path(exists=True))
-def mount(domain, iso_path):
+@click.command(help='Mount ISO into guest',
+               no_args_is_help=True)
+@click.argument('iso_path',
+                type=click.Path(exists=True))
+@click.option('--domain', 'domain_name',
+              type=str,
+              default='vm-0',
+              show_default=True,
+              help='Domain name (i.e. Virtual Machine name)')
+def mount(iso_path, domain_name):
     '''Inject ISO file into specified guest vm.
     Domain can be retrieved by running "xl list" command on the host.
     '''
-    subprocess.run(['xl', 'qemu-monitor-command', domain, f'change ide-5632 {iso_path}'])
+    iso_path_full = os.path.abspath(iso_path)
+    subprocess.run(['xl', 'qemu-monitor-command', domain_name, f'change ide-5632 {iso_path_full}'])
 
 
 @click.group()


### PR DESCRIPTION
Modify `draksetup mount` invocation to match the docs:
https://github.com/CERT-Polska/drakvuf-sandbox/blob/master/docs/usage/getting_started.rst

> Extra software: At this point you might optionally install additional software. You can execute:
> `# draksetup mount /path/to/some-cd.iso`