### PR TITLE
Block plugins introducing instability: dkommon, envmon

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -507,6 +507,8 @@ class DrakrunKarton(Karton):
                                "-x", "poolmon",
                                "-x", "objmon",
                                "-x", "socketmon",
+                               "-x", "dkommon",
+                               "-x", "envmon",
                                "-j", "5",
                                "-t", str(timeout),
                                "-i", inject_pid,


### PR DESCRIPTION
Disable plugins that are reducing stability at the moment:

* `dkommon` - causes hang of Windows 10 2004, needs inspection in future;
* `envmon` - in some circumstances causes DRAKVUF not being able to start (some hooks required by the plugin can not be applied and there is no fallback);