### PR TITLE
fix bug in config.dist.ini (instance)

### DIFF
--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -39,4 +39,4 @@ dns_server=8.8.8.8
 syscall_filter=
 
 ; override Karton instance name for this service:
-;   instance=karton.drakrun-prod
+;   identity=karton.drakrun-prod


### PR DESCRIPTION
We check for key `identity`, not `instance`:
https://github.com/CERT-Polska/drakvuf-sandbox/blob/d91731ec1cc55ac9f17b1cd6c4c4a1983bdcf757/drakrun/drakrun/main.py#L619