### PR TITLE
drakcore: Load analysis list from cache

### DIFF
--- a/drakcore/drakcore/database.py
+++ b/drakcore/drakcore/database.py
@@ -1,7 +1,7 @@
 import json
 from msql import BaseDb
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Tuple
 
 AnalysisMetadata = Dict[str, Any]
 
@@ -18,3 +18,15 @@ class Database(BaseDb):
         with self.get_cursor() as cursor:
             cursor.execute("INSERT INTO metadata (uid, value) VALUES (?, ?)",
                            (analysis_uid, json.dumps(metadata)))
+
+    def get_latest_metadata(self, limit: int = 100, offset: int = 0) -> Dict[str, Any]:
+        def into_result(row):
+            return dict(id=row["uid"], meta=json.loads(row["value"]))
+        with self.get_cursor() as cursor:
+            cursor.execute(("SELECT uid, value "
+                            "FROM metadata "
+                            "ORDER BY json_extract(value, '$.time_finished') DESC "
+                            "LIMIT ? "
+                            "OFFSET ?"), (limit, offset))
+            result = cursor.fetchall()
+            return map(into_result, result)

--- a/drakcore/drakcore/postprocess/cacheupdate.py
+++ b/drakcore/drakcore/postprocess/cacheupdate.py
@@ -1,0 +1,18 @@
+from drakcore.postprocess import postprocess
+from drakcore.app import get_analysis_metadata
+from karton2 import Task, RemoteResource
+from typing import Dict
+
+
+@postprocess(required=["metadata.json"])
+def insert_metadata(task: Task, resources: Dict[str, RemoteResource], minio):
+    """
+    Why is this required?
+    Currently there's no easy way to notify web application about the analysis
+    being finished. In order for it to find out, user has to explicitly ask
+    an endpoint for metadata of given analysis. Otherwise we're be forced to
+    query MinIO every time user requests a list of analyses.
+    """
+    analysis_uid = task.payload["analysis_uid"]
+    # Trigger metadata request, thus pulling it into cache
+    get_analysis_metadata(analysis_uid)


### PR DESCRIPTION
Instead of asking MinIO every time someone requests a list of metadata,
load them directly from the local database. This significantly speeds up
the requests, however introduces additional obstacle - how to populate
the local cache. Solve this by abusing the postprocess service - trigger a
request for metadata on a newly received analysis.