### PR TITLE
Add stub of optional IPT support

### DIFF
--- a/drakcore/drakcore/postprocess/__init__.py
+++ b/drakcore/drakcore/postprocess/__init__.py
@@ -6,6 +6,7 @@ from drakcore.postprocess.generate_graphs import generate_graphs
 from drakcore.postprocess.log_index import generate_log_index
 from drakcore.postprocess.pstree import build_process_tree
 from drakcore.postprocess.slice_logs import slice_drakmon_logs
+from drakcore.postprocess.ipt_disasm import generate_ipt_disasm
 
 PostprocessPlugin = namedtuple("PostprocessPlugin", ('handler', 'required'))
 
@@ -21,6 +22,8 @@ REGISTERED_PLUGINS = [
     PostprocessPlugin(process_api_log, required=['apimon.log']),
     # yields process_tree.json
     PostprocessPlugin(build_process_tree, required=['procmon.log']),
+
+    PostprocessPlugin(generate_ipt_disasm, required=['ipt.zip']),
 
     # yields index/{name}
     PostprocessPlugin(generate_log_index, required=[]),

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import json
 import pprint
 from pathlib import Path
 from functools import reduce
@@ -9,7 +10,7 @@ import tempfile
 
 from karton2 import Task, RemoteResource
 from typing import Dict
-from drakcore.postprocess.ipt_utils import load_drakvuf_output, hexint, get_fault_va, get_fault_pa, get_trap_pa, get_frame_va, page_align, is_page_aligned, select_cr3
+from drakcore.postprocess.ipt_utils import log, load_drakvuf_output, hexint, get_fault_va, get_fault_pa, get_trap_pa, get_frame_va, page_align, is_page_aligned, select_cr3
 from zipfile import ZipFile
 
 
@@ -65,7 +66,6 @@ def match_frames(page_faults, frames, foreign_frames):
         va_page = page_align(va)
         pa_page = page_align(pa)
 
-        has_frame = False
         frame = select_frame(frame_map[va_page], pa_page)
 
         if frame is None:

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -1,0 +1,183 @@
+import os
+import argparse
+import pprint
+from pathlib import Path
+from functools import reduce
+from collections import defaultdict
+import subprocess
+import tempfile
+
+from karton2 import Task, RemoteResource
+from typing import Dict
+from drakcore.postprocess.ipt_utils import *
+from zipfile import ZipFile
+
+
+def debug_faults(page_faults):
+    faulted_pages = sorted(set(page_align((get_fault_va(fault))) for fault in page_faults))
+
+    ranges = []
+    current = []
+    for a, b in zip(faulted_pages, faulted_pages[1:]):
+        current.append(a)
+        if (b - a) == 0x1000:
+            continue
+        else:
+            ranges.append(current)
+            current = []
+        
+    for chunk in ranges:
+        beg = chunk[0]
+        end = chunk[-1] + 0xfff
+        length = (end + 1 - beg) / 0x1000
+        log.debug("%#016x - %#016x (%d pages)", beg, end, length)
+
+def build_frame_va_map(frames):
+    frame_map = defaultdict(list)
+    for frame in frames:
+        addr = page_align(get_frame_va(frame))
+        frame_map[addr].append(frame)
+    return frame_map
+
+def select_frame(frames, phys_addr):
+    for frame in frames:
+        if phys_addr == page_align(get_trap_pa(frame)):
+            return frame
+    return None
+
+def match_frames(page_faults, frames, foreign_frames):
+    log.info("Matching frames for each fault")
+
+    frame_map = build_frame_va_map(frames)
+    foreign_frame_map = build_frame_va_map(foreign_frames)
+
+
+    unresolved = 0
+    foreign_resolved = 0
+    results = []
+
+    for fault in page_faults:
+        va = get_fault_va(fault)
+        pa = get_fault_pa(fault)
+
+
+        va_page = page_align(va)
+        pa_page = page_align(pa)
+
+        has_frame = False
+        frame = select_frame(frame_map[va_page], pa_page)
+
+        if frame is None:
+            frame = select_frame(foreign_frame_map[va_page], pa_page)
+            if frame is None:
+                unresolved += 1
+            else:
+                foreign_resolved += 1
+        log.info("%#016x -> %s", va_page, frame['FrameFile'] if frame else "?")
+        if frame:
+            results.append((va_page, frame['FrameFile']))
+
+    log.info("Failed to resolve %d faults. Let's hope they're not related to code", unresolved)
+    log.info("Resolved %d from external CR3", foreign_resolved)
+
+    return results
+
+
+def main(analysis_dir, cr3_value):
+    log.debug("Analysis directory: %s", analysis_dir)
+    log.debug("CR3: %#x", cr3_value)
+
+    if not is_page_aligned(cr3_value):
+        log.critical("CR3 must be aligned to page! Got %#x", cr3_value)
+        return
+
+
+    page_faults = load_drakvuf_output(analysis_dir / "pagefault.log")
+    executed_frames = load_drakvuf_output(analysis_dir / "execframe.log")
+
+
+    faults_in_process = list(select_cr3(lambda cr3: cr3 == cr3_value, page_faults))
+    frames_in_process = list(select_cr3(lambda cr3: cr3 == cr3_value, executed_frames))
+    frames_out_process = list(select_cr3(lambda cr3: cr3 != cr3_value, executed_frames))
+
+    log.info("%d frames dumped from this process", len(frames_in_process))
+    log.info("%d frames outside this process", len(frames_out_process))
+    log.info("%d faults in process", len(faults_in_process))
+
+
+    faults_in_process.sort(key=get_fault_va)
+    debug_faults(faults_in_process)
+    mappings = match_frames(faults_in_process, frames_in_process, frames_out_process)
+
+    pages = []
+    for addr, fname in mappings:
+        name = Path(fname).name
+        fpath = analysis_dir / "ipt" / "frames" / name
+        if fpath.stat().st_size == 0x1000:
+            pages.append("--raw")
+            pages.append(f"{fpath}:0x{addr:x}")
+    ptxed_cmdline = [
+        "/opt/libipt/bin/ptxed",
+        "--block-decoder",
+        "--pt",
+        os.path.join(analysis_dir, "ipt", "ipt_stream_vcpu0"),
+        *pages
+    ]
+
+    log.error("IPT: Generated ptxed command line: %s", ptxed_cmdline)
+    ptxed_proc = subprocess.Popen(subprocess.list2cmdline(ptxed_cmdline), shell=True, stdout=subprocess.PIPE)
+    cnt = 0
+
+    while True:
+        line = ptxed_proc.stdout.readline()
+
+        if not line:
+            break
+
+        cnt += 1
+
+    log.info("IPT: Disasm length %d", cnt)
+
+
+def generate_ipt_disasm(task: Task, resources: Dict[str, RemoteResource], minio):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        resources["inject.log"].download_to_file(str(tmpdir / "inject.log"))
+
+        with open(str(tmpdir / "inject.log"), "r") as f:
+            inject_log = json.loads(f.read().split('\n')[0].strip())
+
+        injected_pid = inject_log["InjectedPid"]
+        resources["syscall.log"].download_to_file(str(tmpdir / "syscall.log"))
+
+        with open(str(tmpdir / "syscall.log"), "r") as f:
+            for line in f:
+                obj = json.loads(line)
+
+                if obj.get("PID") == injected_pid:
+                    injected_cr3 = int(obj["CR3"], 16)
+                    break
+            else:
+                log.error("Failed to find injected process' CR3, not doing IPT disasm")
+                return
+
+        resources["pagefault.log"].download_to_file(str(tmpdir / "pagefault.log"))
+        resources["execframe.log"].download_to_file(str(tmpdir / "execframe.log"))
+
+        with resources["ipt.zip"].download_temporary_file() as ipt_zip_tmp:
+            with ZipFile(ipt_zip_tmp) as ipt_zip:
+                ipt_zip.extractall(tmpdir)
+
+        main(tmpdir, injected_cr3)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("analysis_dir", help="Analysis output directory")
+    parser.add_argument("cr3_value", type=hexint, help="CR3 value of process of interest")
+    args = parser.parse_args()
+
+    analysis_dir = Path(args.analysis_dir)
+    cr3_value = args.cr3_value
+
+    main(analysis_dir, cr3_value)

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -153,7 +153,7 @@ def generate_ipt_disasm(task: Task, resources: Dict[str, RemoteResource], minio)
                 obj = json.loads(line)
 
                 if obj.get("PID") == injected_pid:
-                    injected_cr3 = int(obj["CR3"], 16)
+                    injected_cr3 = hexint(obj["CR3"])
                     break
             else:
                 log.error("Failed to find injected process' CR3, not doing IPT disasm")

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -26,7 +26,7 @@ def debug_faults(page_faults):
         else:
             ranges.append(current)
             current = []
-        
+
     for chunk in ranges:
         beg = chunk[0]
         end = chunk[-1] + 0xfff

--- a/drakcore/drakcore/postprocess/ipt_utils.py
+++ b/drakcore/drakcore/postprocess/ipt_utils.py
@@ -46,26 +46,34 @@ def load_drakvuf_output(path):
     log.info("Loaded %d entries", len(result))
     return result
 
+
 def hexint(v):
     return int(v, 16)
+
 
 def get_fault_va(fault):
     return hexint(fault['VA'])
 
+
 def get_fault_pa(fault):
     return hexint(fault['PA'])
+
 
 def get_trap_pa(execframe):
     return hexint(execframe['TrapPA'])
 
+
 def get_frame_va(execframe):
     return hexint(execframe['FrameVA'])
+
 
 def page_align(addr):
     return addr & ~0xfff
 
+
 def is_page_aligned(addr):
     return (addr & 0xfff) == 0
+
 
 def select_cr3(pred, entries):
     return filter(lambda v: pred(hexint(v['CR3'])), entries)

--- a/drakcore/drakcore/postprocess/ipt_utils.py
+++ b/drakcore/drakcore/postprocess/ipt_utils.py
@@ -1,0 +1,71 @@
+import logging
+import json
+
+class CustomFormatter(logging.Formatter):
+    """Logging Formatter to add colors and count warning / errors"""
+
+    grey = "\x1b[38;21m"
+    yellow = "\x1b[33;21m"
+    red = "\x1b[31;21m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    format = "%(levelname)8s - %(message)s"
+    #format = "%(asctime)s %(levelname)8s - %(message)s (%(filename)s:%(lineno)d)"
+
+    FORMATS = {
+        logging.DEBUG: grey + format + reset,
+        logging.INFO: grey + format + reset,
+        logging.WARNING: yellow + format + reset,
+        logging.ERROR: red + format + reset,
+        logging.CRITICAL: bold_red + format + reset
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+ch.setFormatter(CustomFormatter())
+
+log = logging.getLogger("hax")
+log.setLevel(logging.DEBUG)
+log.addHandler(ch)
+
+
+def load_drakvuf_output(path):
+    log.info("Parsing %s...", path.name)
+    result = []
+    with path.open() as f:
+        for line in f:
+            try:
+                result.append(json.loads(line))
+            except json.JSONDecodeError:
+                log.warning("Failed to parse %s", line)
+    log.info("Loaded %d entries", len(result))
+    return result
+
+def hexint(v):
+    return int(v, 16)
+
+def get_fault_va(fault):
+    return hexint(fault['VA'])
+
+def get_fault_pa(fault):
+    return hexint(fault['PA'])
+
+def get_trap_pa(execframe):
+    return hexint(execframe['TrapPA'])
+
+def get_frame_va(execframe):
+    return hexint(execframe['FrameVA'])
+
+def page_align(addr):
+    return addr & ~0xfff
+
+def is_page_aligned(addr):
+    return (addr & 0xfff) == 0
+
+def select_cr3(pred, entries):
+    return filter(lambda v: pred(hexint(v['CR3'])), entries)

--- a/drakcore/drakcore/postprocess/ipt_utils.py
+++ b/drakcore/drakcore/postprocess/ipt_utils.py
@@ -1,6 +1,7 @@
 import logging
 import json
 
+
 class CustomFormatter(logging.Formatter):
     """Logging Formatter to add colors and count warning / errors"""
 
@@ -10,7 +11,7 @@ class CustomFormatter(logging.Formatter):
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
     format = "%(levelname)8s - %(message)s"
-    #format = "%(asctime)s %(levelname)8s - %(message)s (%(filename)s:%(lineno)d)"
+    # format = "%(asctime)s %(levelname)8s - %(message)s (%(filename)s:%(lineno)d)"
 
     FORMATS = {
         logging.DEBUG: grey + format + reset,
@@ -24,6 +25,7 @@ class CustomFormatter(logging.Formatter):
         log_fmt = self.FORMATS.get(record.levelno)
         formatter = logging.Formatter(log_fmt)
         return formatter.format(record)
+
 
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)

--- a/drakcore/drakcore/postprocess/log_index.py
+++ b/drakcore/drakcore/postprocess/log_index.py
@@ -11,8 +11,10 @@ so we build and index, to quickly look up where n-th line begins.
 """
 import io
 import json
+import logging
 from karton2 import Task, RemoteResource
 from typing import Dict
+from minio.error import NoSuchKey
 
 
 def line_marker(line, offset):
@@ -53,8 +55,12 @@ def generate_log_index(task: Task, resources: Dict[str, RemoteResource], minio):
         # TODO - use resource metadata
         if not name.endswith(".log"):
             continue
-        with resource.download_temporary_file() as tmp_file:
-            index = generate_file_index(tmp_file)
-            data = json.dumps(index).encode()
-            stream = io.BytesIO(data)
-            minio.put_object("drakrun", f"{analysis_uid}/index/{name}", stream, len(data))
+        try:
+            with resource.download_temporary_file() as tmp_file:
+                index = generate_file_index(tmp_file)
+                data = json.dumps(index).encode()
+                stream = io.BytesIO(data)
+                minio.put_object("drakrun", f"{analysis_uid}/index/{name}", stream, len(data))
+        except NoSuchKey:
+            # some resources might be already deleted by other plugins
+            pass

--- a/drakcore/drakcore/postprocess/log_index.py
+++ b/drakcore/drakcore/postprocess/log_index.py
@@ -11,7 +11,6 @@ so we build and index, to quickly look up where n-th line begins.
 """
 import io
 import json
-import logging
 from karton2 import Task, RemoteResource
 from typing import Dict
 from minio.error import NoSuchKey

--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -40,3 +40,7 @@ syscall_filter=
 
 ; override Karton instance name for this service:
 ;   identity=karton.drakrun-prod
+
+; use Intel Processor Trace (experimental)
+; special version of drakvuf-bundle is required
+enable_ipt=0

--- a/drakrun/drakrun/injector.py
+++ b/drakrun/drakrun/injector.py
@@ -29,9 +29,9 @@ class Injector:
         cmd.extend(["-B", local])
         return cmd
 
-    def _get_cmdline_createproc(self, cmd: str, wait: bool = False) -> List[str]:
+    def _get_cmdline_createproc(self, exec_cmd: str, wait: bool = False) -> List[str]:
         cmd = self._get_cmdline_generic("createproc")
-        cmd.extend(["-e", cmd])
+        cmd.extend(["-e", exec_cmd])
         if wait:
             cmd.append("-w")
         return cmd

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -205,6 +205,13 @@ class DrakrunKarton(Karton):
         if current_size > max_total_size:
             self.log.error('Some dumps were deleted, because the configured size threshold was exceeded.')
 
+    def compress_ipt(self, dirpath, target_zip):
+        zipf = zipfile.ZipFile(target_zip, 'w', zipfile.ZIP_DEFLATED)
+
+        for root, dirs, files in os.walk(dirpath):
+            for file in files:
+                zipf.write(os.path.join(root, file), os.path.join("ipt", os.path.relpath(os.path.join(root, file), dirpath)))
+
     def upload_artifacts(self, analysis_uid, workdir, subdir=''):
         base_path = os.path.join(workdir, 'output')
 
@@ -311,6 +318,7 @@ class DrakrunKarton(Karton):
         outdir = os.path.join(workdir, 'output')
         os.mkdir(outdir)
         os.mkdir(os.path.join(outdir, 'dumps'))
+        os.mkdir(os.path.join(outdir, 'ipt'))
 
         metadata = {
             "sample_sha256": sha256sum,
@@ -339,6 +347,7 @@ class DrakrunKarton(Karton):
                 hooks_list = os.path.join(ETC_DIR, "hooks.txt")
                 kernel_profile = os.path.join(PROFILE_DIR, "kernel.json")
                 dump_dir = os.path.join(outdir, "dumps")
+                ipt_dir = os.path.join(outdir, "ipt")
                 drakmon_log_fp = os.path.join(outdir, "drakmon.log")
 
                 self.log.info("Copying sample to VM...")
@@ -384,6 +393,9 @@ class DrakrunKarton(Karton):
                                "-r", kernel_profile,
                                "-e", full_cmd,
                                "-c", cwd]
+
+                if self.config.config['drakrun'].get('enable_ipt', '0') == '1':
+                    drakvuf_cmd.extend(["--ipt-dir", ipt_dir])
 
                 drakvuf_cmd.extend(self.get_profile_list())
 
@@ -433,6 +445,10 @@ class DrakrunKarton(Karton):
                 self.log.exception("tcpdump doesn't exit cleanly after 60s")
 
         self.crop_dumps(os.path.join(outdir, 'dumps'), os.path.join(outdir, 'dumps.zip'))
+
+        if self.config.config['drakrun'].get('enable_ipt', '0') == '1':
+            self.compress_ipt(os.path.join(outdir, 'ipt'), os.path.join(outdir, 'ipt.zip'))
+
         self.log.info("uploading artifacts")
 
         metadata['time_finished'] = int(time.time())

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -394,7 +394,7 @@ class DrakrunKarton(Karton):
                                "-e", full_cmd,
                                "-c", cwd]
 
-                if self.config.config['drakrun'].get('enable_ipt', '0') == '1':
+                if self.config.config['drakrun'].getboolean('enable_ipt', fallback=False):
                     drakvuf_cmd.extend(["--ipt-dir", ipt_dir])
 
                 drakvuf_cmd.extend(self.get_profile_list())
@@ -446,7 +446,7 @@ class DrakrunKarton(Karton):
 
         self.crop_dumps(os.path.join(outdir, 'dumps'), os.path.join(outdir, 'dumps.zip'))
 
-        if self.config.config['drakrun'].get('enable_ipt', '0') == '1':
+        if self.config.config['drakrun'].getboolean('enable_ipt', fallback=False):
             self.compress_ipt(os.path.join(outdir, 'ipt'), os.path.join(outdir, 'ipt.zip'))
 
         self.log.info("uploading artifacts")

--- a/drakrun/drakrun/scripts/cfg.template
+++ b/drakrun/drakrun/scripts/cfg.template
@@ -24,3 +24,4 @@ cpuid="host,htt=0"
 vga="stdvga"
 vif = [ 'type=ioemu,model=e1000,bridge=drak{{ VM_ID }}' ]
 disk = [ {{ DISKS }} ]
+processor_trace_buf_kb = 65536


### PR DESCRIPTION
drakvuf-bundle must be built from branch https://github.com/CERT-Polska/drakvuf/tree/sandbox-ipt-work and ran on a processor which supports IPT

Currently, the stub is able to run `ptxed` and report how many lines there were in disassembly.