### PR TITLE
Adding a client library and CLI utility for interacting with DRAKVUF Sandbox

### DIFF
--- a/examples/sandboxapi/README.md
+++ b/examples/sandboxapi/README.md
@@ -1,5 +1,15 @@
 # Python client for [DRAKVUF Sandbox](https://github.com/CERT-Polska/drakvuf-sandbox)
 
+## Overview
+
+sandboxapi is a client implementation in Python for the API exposed by
+[DRAKVUF Sandbox](https://github.com/CERT-Polska/drakvuf-sandbox). Below, you'll find some installation and usage
+instructions.
+
+# Prerequisites:
+- Python 3
+- A running DRAKVUF Sandbox instance on an accessible host
+
 ## Installation
 
 * Clone this repo
@@ -9,9 +19,7 @@
     pip install .
     ```
 
-**NOTE**: written for Python 3
-
-## Using the API
+## Using the API Programmatically
 
 ### Instantiating a client
 
@@ -62,7 +70,7 @@ Options for logs to pull include (non-exhaustive):
 * regmon
 * syscalls
 
-## Using the CLI
+## Using the API from the CLI
 
 ```
 $ sandboxcli -h

--- a/examples/sandboxapi/README.md
+++ b/examples/sandboxapi/README.md
@@ -1,0 +1,139 @@
+# Python client for [DRAKVUF Sandbox](https://github.com/CERT-Polska/drakvuf-sandbox)
+
+## Installation
+
+* Clone this repo
+* Run:
+
+    ```bash
+    pip install .
+    ```
+
+**NOTE**: written for Python 3
+
+## Using the API
+
+### Instantiating a client
+
+```python
+# specify your URL
+client = Client(url="http://localhost:6300")
+# or specify none and use the default of http://localhost:6300
+client = Client()
+```
+
+### Submit a file
+
+```python
+# submit a file and get the UUID of the new job in response
+uuid = client.post_file("/path/to/file")
+```
+
+### Check job status
+
+```python
+# get the status of the given job (e.g. "pending")
+status = client.get_status("<UUID>")
+```
+
+### Retrieve mem dump
+
+```python
+# download the mem dump for a job, with the HTTP code and filepath written to returned
+status_code, outfilepath = client.get_dump("<UUID>")
+```
+
+### Retrieve log
+
+```python
+# download the log for a job, with the HTTP code and filepath written to returned
+status_code, outfilepath = client.get_log("<UUID>", "apimon")
+```
+
+Options for logs to pull include (non-exhaustive):
+* apimon
+* cpuidmon
+* delaymon
+* dkommon
+* exmon
+* filetracer
+* memdump
+* procmon
+* regmon
+* syscalls
+
+## Using the CLI
+
+```
+$ sandboxcli -h
+usage: sandboxcli [-h] [-f FILEPATH] [-d DUMP_UUID] [-l LOG] [-s STATUS_UUID]
+                  [-u URL] [-w]
+
+Interact with DRAKVUF Sandbox
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f FILEPATH, --filepath FILEPATH
+                        Path for file to be submitted
+  -d DUMP_UUID, --dump-uuid DUMP_UUID
+                        UUID of the memory dump to download
+  -l LOG, --log-download LOG
+                        The UUID and the name of the log to download,
+                        specified as <UUID>:<logname>
+  -s STATUS_UUID, --status-uuid STATUS_UUID
+                        UUID of the job to check the status of
+  -u URL, --url URL     DRAKVUF Sandbox server URL (default:
+                        http://localhost:6300)
+  -w, --wait            If passed, CLI won't return until analysis ends
+```
+
+### Submit a file
+
+You can submit a file asynchronously
+
+```bash
+$ sandboxcli -f sample.exe
+Submitted file sample.exe with job UUID <UUID>
+```
+
+Or, you can wait until the job completes
+```bash
+$ sandboxcli -f sample.exe
+Submitted file sample.exe with job UUID <UUID>
+Task <UUID> pending... (0s)
+Task <UUID> pending... (10s)
+Task <UUID> pending... (20s)
+Task <UUID> pending... (30s)
+Task <UUID> pending... (40s)
+Task <UUID> pending... (50s)
+Task <UUID> pending... (60s)
+Task <UUID> pending... (70s)
+Task <UUID> pending... (80s)
+Task <UUID> pending... (90s)
+...
+```
+
+### Check job status
+
+```bash
+$ sandboxcli -s <UUID>
+Job <UUID>: pending
+```
+
+### Retrieve mem dump
+
+```bash
+$ sandboxcli -d <UUID>
+200: downloaded <UUID>.dump
+```
+
+### Retrieve log
+
+```bash
+$ sandboxcli -l <UUID>:apimon
+200: downloaded <UUID>-apimon.json
+```
+
+## Future Work
+
+* Add options for run time and detonation command to `post_file`

--- a/examples/sandboxapi/sandboxapi/cli.py
+++ b/examples/sandboxapi/sandboxapi/cli.py
@@ -1,0 +1,86 @@
+import argparse
+import time
+from sandboxapi.client import Client
+
+
+parser = argparse.ArgumentParser(description='Interact with DRAKVUF Sandbox')
+parser.add_argument(
+    '-f',
+    '--filepath',
+    dest='filepath',
+    help='Path for file to be submitted'
+)
+parser.add_argument(
+    '-d',
+    '--dump-uuid',
+    dest="dump_uuid",
+    help="UUID of the memory dump to download"
+)
+parser.add_argument(
+    '-l',
+    '--log-download',
+    dest='log',
+    help='The UUID and the name of the log to download, specified as <UUID>:<logname>'
+)
+parser.add_argument(
+    '-s',
+    '--status-uuid',
+    dest='status_uuid',
+    help='UUID of the job to check the status of'
+)
+parser.add_argument(
+    '-u',
+    '--url',
+    dest='url',
+    default="http://localhost:6300",
+    help='DRAKVUF Sandbox server URL (default: http://localhost:6300)'
+)
+parser.add_argument(
+    '-w',
+    '--wait',
+    dest='wait',
+    action="store_true",
+    help='If passed, CLI won\'t return until analysis ends'
+)
+
+
+def main():
+    # Modeled after:
+    # - https://github.com/CERT-Polska/drakvuf-sandbox/blob/master/examples/push_sample.py
+
+    # parse args and init client
+    args = parser.parse_args()
+    client = Client(args.url)
+
+    # submit file if flag passed
+    if args.filepath:
+        uuid = client.post_file(args.filepath)
+        print(f"Submitted file {args.filepath} with job UUID {uuid}")
+
+        # iterate until status changes if wait passed
+        seconds = 0
+        if args.wait:
+            while True:
+                status = client.get_status(uuid)
+
+                if status != "pending":
+                    break
+                print(f"Task {uuid} {status}... ({seconds}s)")
+                time.sleep(10)
+                seconds += 10
+
+    # pull log if flag passed
+    if args.log:
+        uuid, logname = args.log.split(":")
+        status_code, outfilepath = client.get_log(uuid, logname)
+        print(f"{status_code}: downloaded {outfilepath}")
+
+    # pull mem dump if flag passed
+    if args.dump_uuid:
+        status_code, outfilepath = client.get_dump(args.dump_uuid)
+        print(f"{status_code}: downloaded {outfilepath}")
+
+    # check status if flag passed
+    if args.status_uuid:
+        status = client.get_status(args.status_uuid)
+        print(f"Job {args.status_uuid}: {status}")

--- a/examples/sandboxapi/sandboxapi/cli.py
+++ b/examples/sandboxapi/sandboxapi/cli.py
@@ -1,3 +1,14 @@
+"""CLI wrapper around the sandboxapi Client implementation for DRAKVUF Sandbox.
+
+This module provides a CLI wrapping the Client class exposed by client.py, facilitating pushing files to and pulling
+results from DRAKVUF Sandbox via the command line.
+
+  Typical usage example (see README.md for more usage info):
+
+  $ sandboxcli -f sample.exe
+  Submitted file sample.exe with job UUID <UUID>
+"""
+
 import argparse
 import time
 from sandboxapi.client import Client

--- a/examples/sandboxapi/sandboxapi/client.py
+++ b/examples/sandboxapi/sandboxapi/client.py
@@ -1,3 +1,16 @@
+"""Client implementation for DRAKVUF Sandbox.
+
+This module exposes the Client class, which can be instantiated to begin interfacing with DRAKVUF Sandbox
+programmatically
+
+  Typical usage example (see README.md for more usage info):
+
+  # instantiate a client
+  client = Client(url="http://localhost:6300")
+  # submit a file and get the UUID of the new job in response
+  uuid = client.post_file("/path/to/file")
+"""
+
 import requests
 from typing import Tuple
 

--- a/examples/sandboxapi/sandboxapi/client.py
+++ b/examples/sandboxapi/sandboxapi/client.py
@@ -1,0 +1,115 @@
+import requests
+from typing import Tuple
+
+
+class Client(object):
+    """
+    Simple API client for DRAKVUF Sandbox
+
+    Modeled after:
+    - https://github.com/CERT-Polska/drakvuf-sandbox/blob/master/examples/push_sample.py
+    - https://stackoverflow.com/questions/16694907/download-large-file-in-python-with-requests
+    """
+
+    def __init__(self, url: str):
+        """
+        Constructor
+
+        Args:
+            url (str): the URL of the server e.g. http://localhost:6300
+        """
+        # create URLs
+        self.base_url = url
+        self.upload_url = f"{self.base_url}/upload"
+        self.status_url = f"{self.base_url}/status"
+        self.dump_url = f"{self.base_url}/dumps"
+        self.log_url = f"{self.base_url}/logs"
+
+    def post_file(self, path: str) -> str:
+        """
+        Submits a file
+
+        Args:
+            path (str):
+
+        Returns:
+            str: the task UUID
+        """
+        with open(path, 'rb') as sample:
+            response = requests.post(self.upload_url, files={'file': sample})
+            response.raise_for_status()
+        json = response.json()
+        try:
+            return json['task_uid']
+        except KeyError:
+            raise KeyError("'task_uid' not in the JSON response")
+
+    def get_status(self, uuid: str) -> str:
+        """
+        Retrieve status of analysis job
+
+        Args:
+            uuid (str): the UUID to retrieve a status for
+
+        Returns:
+            str: the status (e.g. 'pending')
+        """
+        url = f"{self.status_url}/{uuid}"
+        response = requests.get(url)
+        response.raise_for_status()
+        json = response.json()
+        try:
+            return json['status']
+        except KeyError:
+            raise KeyError("'status' not in the JSON response")
+
+    def get_dump(self, uuid: str) -> Tuple[int, str]:
+        """
+        Download the mem dump for the given analysis
+
+        Args:
+            uuid (str): the UUID of the analysis
+
+        Returns:
+            tuple: an int (status code) and a str (filename written to)
+
+        """
+        url = f"{self.dump_url}/{uuid}"
+        outfilepath = f"{uuid}.dump"
+        return Client.download_file(url, outfilepath)
+
+    def get_log(self, uuid: str, logname: str) -> Tuple[int, str]:
+        """
+        Download a log file for a given analysis
+
+        Args:
+            uuid (str): the UUID of the analysis
+            logname (str): the name of the log (e.g. apimon)
+
+        Returns:
+            tuple: an int (status code) and a str (filename written to)
+
+        """
+        url = f"{self.log_url}/{uuid}/{logname}"
+        outfilepath = f"{uuid}-{logname}.json"
+        return Client.download_file(url, outfilepath)
+
+    @staticmethod
+    def download_file(url: str, filepath: str) -> Tuple[int, str]:
+        """
+        Downloads a file from a URL in chunks and writes it to disk
+
+        Args:
+            url (str): the URL
+            filepath (str): the file to write to
+
+        Returns:
+            tuple: an int (status code) and a str (filename written to)
+
+        """
+        with requests.get(url, stream=True) as response:
+            response.raise_for_status()
+            with open(filepath, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        return response.status_code, filepath

--- a/examples/sandboxapi/setup.py
+++ b/examples/sandboxapi/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='sandboxapi',
+    version='0.1',
+    description='Simple client-side API binding for DRAKVUF Sandbox',
+    packages=find_packages(),
+    install_requires=[
+        'requests'
+    ],
+    entry_points={
+        'console_scripts': ['sandboxcli=sandboxapi.cli:main'],
+    }
+)


### PR DESCRIPTION
This PR supplies a new utility under the `examples/` directory called `sandboxapi`. 
- `client.py` provides a client class for interacting with the Sandbox programmatically
- `cli.py` provides a CLI wrapper called `sandboxcli` for easy interaction with the API.