### PR TITLE
drakcore: Handle missing key in /status

### DIFF
--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -187,7 +187,10 @@ def status(task_uid):
     res = {"status": "done"}
 
     for task_key in tasks:
-        task = json.loads(rs.get(task_key))
+        data = rs.get(task_key)
+        if not data:
+            continue
+        task = json.loads(data)
 
         if task["root_uid"] == task_uid:
             if task["status"] != "Finished":


### PR DESCRIPTION
When iterating over tasks it might happen, that we try to load
a task which was already cleaned up. In this case, skip it.