### PR TITLE
Add "use_root_uid" config setting to preserve compatibility with pre-OSS

### DIFF
--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -38,6 +38,15 @@ dns_server=8.8.8.8
 ; leave empty to use no filter
 syscall_filter=
 
+; default analysis timeout if not specified by the user
+;   analysis_timeout=600
+
+; store analysis artifacts under root_uid of the Karton's task
+; instead of storing it under the uid of actual task;
+; this is more user friendly but causes that your task trees
+; will be not able to invoke DRAKVUF Sandbox more than once
+;   use_root_uid=1
+
 ; (advanced) override Karton instance name for this service:
 ;   identity=karton.drakrun-prod
 
@@ -47,9 +56,6 @@ syscall_filter=
 ; (advanced) override Karton output headers for this service:
 ;   headers=[{"type": "analysis", "kind": "drakrun"}]
 
-; use Intel Processor Trace (experimental)
+; (advanced) (experimental) use Intel Processor Trace
 ; special version of drakvuf-bundle is required
 enable_ipt=0
-
-; Default analysis timeout if not specified by the user
-; analysis_timeout=600

--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -43,8 +43,8 @@ syscall_filter=
 
 ; store analysis artifacts under root_uid of the Karton's task
 ; instead of storing it under the uid of actual task;
-; this is more user friendly but causes that your task trees
-; will be not able to invoke DRAKVUF Sandbox more than once
+; this is more user friendly but your task trees
+; won't be able to invoke DRAKVUF Sandbox more than once
 ;   use_root_uid=1
 
 ; (advanced) override Karton instance name for this service:

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -291,6 +291,8 @@ class DrakrunKarton(Karton):
 
         if self.config.getboolean('drakrun', 'use_root_uid'):
             return self.current_task.root_uid
+        
+        return self.current_task.uid
 
     @with_logs('drakrun.log')
     def process(self):

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -291,7 +291,7 @@ class DrakrunKarton(Karton):
 
         if self.config.getboolean('drakrun', 'use_root_uid'):
             return self.current_task.root_uid
-        
+
         return self.current_task.uid
 
     @with_logs('drakrun.log')

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -285,7 +285,7 @@ class DrakrunKarton(Karton):
     @property
     def analysis_uid(self):
         override_uid = self.current_task.payload.get('override_uid')
-        
+
         if override_uid:
             return override_uid
 


### PR DESCRIPTION
* Refactor `analysis_uid` into property helper function.
* Add `use_root_uid` in `drakrun` section of `config.ini` to let user decide that all analyses should be stored under their root_uids instead of the actual task uids. This is more user friendly but obviously doesn't let to run DRAKVUF Sandbox more than once within a single task tree. I think this is a fair deal.
* We are going to set `use_root_uid=1` in prod.