### PR TITLE
Fix dh-virtualenv installation in package build

### DIFF
--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -6,10 +6,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release dh-virtualenv && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
+    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \
-    pip3 install virtualenv==20.1.0
+    pip3 install virtualenv==20.1.0 && \
+    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 COPY drakcore /build
 WORKDIR /build

--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
-    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
+    curl "http://snapshot.debian.org/archive/debian/20201031T220724Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \

--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -4,14 +4,12 @@ FROM $IMAGE
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release && \
+    apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release dh-virtualenv && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
-    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \
-    pip3 install virtualenv && \
-    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
+    pip3 install virtualenv==20.1.0
 
 COPY drakcore /build
 WORKDIR /build

--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
-    curl "http://snapshot.debian.org/archive/debian/20201031T220724Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
+    curl "http://snapshot.debian.org/archive/debian/20201029T084118Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
     python3 -m pip install pip && \

--- a/drakcore/package/Dockerfile
+++ b/drakcore/package/Dockerfile
@@ -4,7 +4,7 @@ FROM $IMAGE
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release dh-virtualenv && \
+    apt-get install -y wget curl python3 python3-venv python3-pip debhelper devscripts lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev ; else apt-get install -y python3.7 python3.7-dev ; fi && \
     curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -6,9 +6,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     wget curl python3 python3-pip python3-venv debhelper devscripts \
-    libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release dh-virtualenv && \
+    libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
-    pip3 install virtualenv==20.1.0
+    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
+    pip3 install virtualenv==20.0.23 && \
+    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 RUN wget -O drakvuf.deb "https://debs.icedev.pl/manual/drakvuf-bundle/$(lsb_release -cs)/drakvuf-bundle-0.7-git20200501075508+0f828ce-1.deb" && \
     dpkg -i ./drakvuf.deb

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     wget curl python3 python3-pip python3-venv debhelper devscripts \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
-    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
+    curl "http://snapshot.debian.org/archive/debian/20201031T220724Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
     pip3 install virtualenv==20.0.23 && \
     dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -6,11 +6,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     wget curl python3 python3-pip python3-venv debhelper devscripts \
-    libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
+    libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release dh-virtualenv && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
-    curl "https://deb.debian.org/debian/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
-    pip3 install virtualenv==20.0.23 && \
-    dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
+    pip3 install virtualenv==20.1.0
 
 RUN wget -O drakvuf.deb "https://debs.icedev.pl/manual/drakvuf-bundle/$(lsb_release -cs)/drakvuf-bundle-0.7-git20200501075508+0f828ce-1.deb" && \
     dpkg -i ./drakvuf.deb

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
     curl "http://snapshot.debian.org/archive/debian/20201031T220724Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
-    pip3 install virtualenv==20.0.23 && \
+    pip3 install virtualenv==20.1.0 && \
     dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 
 RUN wget -O drakvuf.deb "https://debs.icedev.pl/manual/drakvuf-bundle/$(lsb_release -cs)/drakvuf-bundle-0.7-git20200501075508+0f828ce-1.deb" && \

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     wget curl python3 python3-pip python3-venv debhelper devscripts \
     libpixman-1-0 libpng16-16 libfdt1 libglib2.0-dev 'libjson-c[34]' libyajl2 libaio1 lsb-release && \
     if [ $(apt-cache search --names-only '^python3\.8$' | wc -l) -ne 0 ]; then apt-get install -y python3.8 python3.8-dev python3.8-venv ; else apt-get install -y python3.7 python3.7-dev python3.7-venv ; fi && \
-    curl "http://snapshot.debian.org/archive/debian/20201031T220724Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.2-1_all.deb" -o dh-virtualenv.deb && \
+    curl "http://snapshot.debian.org/archive/debian/20201029T084118Z/pool/main/d/dh-virtualenv/dh-virtualenv_1.2.1-1_all.deb" -o dh-virtualenv.deb && \
     pip3 install virtualenv==20.1.0 && \
     dpkg -i --ignore-depends=sphinx-rtd-theme-common ./dh-virtualenv.deb
 


### PR DESCRIPTION
* `dh-virtualenv` debian package that we were hotlinking was recently removed, thus breaking package build process entirely
* `dh-virtualenv` is now present on all supported distributions, so we might install it normally through `apt-get`