### PR TITLE
Send a task after postprocessing

### DIFF
--- a/drakcore/drakcore/postprocess/slice_logs.py
+++ b/drakcore/drakcore/postprocess/slice_logs.py
@@ -60,4 +60,5 @@ def slice_drakmon_logs(task: Task, resources: Dict[str, RemoteResource], minio):
                 minio.fput_object("drakrun", f"{analysis_uid}/{plugin_name}.log", target_dir / f'{plugin_name}.log')
                 yield f"{plugin_name}.log"
 
+    del resources["drakmon.log"]
     minio.remove_object("drakrun", f"{analysis_uid}/drakmon.log")

--- a/drakcore/drakcore/process.py
+++ b/drakcore/drakcore/process.py
@@ -94,8 +94,8 @@ class AnalysisProcessor(Karton):
                 self.log.error("Postprocess failed", exc_info=True)
 
         task = Task({
-            "type": "postprocess",
-            "kind": "drakcore",
+            "type": "analysis",
+            "kind": "drakrun-processed",
         })
 
         for (name, resource) in task_resources.items():


### PR DESCRIPTION
This should resolve #371 
Currently there's no way to easily wait until postprocessing artifacts are generated. 
Fix this by sending a new task after finishing all postprocessing steps.