### PR TITLE
Fix inconsistent argument parsing in drakpdb, expose it as cmdline tool

### DIFF
--- a/docs/drakpdb.rst
+++ b/docs/drakpdb.rst
@@ -1,0 +1,18 @@
+Using drakpdb tool
+##################
+
+The `drakpdb` tool allows you to:
+
+* determine PDB name and GUID age given an executable file (e.g. DLL)
+* fetch PDB with given name and GUID age
+* parse PDB into a profile that could be plugged into DRAKVUF
+
+Usage examples
+==============
+
+.. code-block:: console
+    root@zen2:~/drakvuf# drakpdb pdb_guid --file ntdll.dll
+    {'filename': 'wntdll.pdb', 'GUID': 'dccff2d483fa4dee81dc04552c73bb5e2'}
+    root@zen2:~/drakvuf# drakpdb fetch_pdb --pdb_name wntdll.pdb --guid_age dccff2d483fa4dee81dc04552c73bb5e2
+    100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.12M/2.12M [00:00<00:00, 2.27MiB/s]
+    root@zen2:~/drakvuf# drakpdb parse_pdb --pdb_name wntdll.pdb > profile.json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Because it is usually pretty hard to set up a malware sandbox, this project also
    :caption: Misc
    
    faq
+   drakpdb
 
 
    

--- a/drakrun/debian/drakrun.links
+++ b/drakrun/debian/drakrun.links
@@ -1,3 +1,4 @@
 opt/venvs/drakrun/bin/draksetup usr/bin/draksetup
 opt/venvs/drakrun/bin/drakrun usr/bin/drakrun
 opt/venvs/drakrun/bin/drakpush usr/bin/drakpush
+opt/venvs/drakrun/bin/drakpdb usr/bin/drakpdb

--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -364,7 +364,7 @@ def main():
         print(make_pdb_profile(args.pdb_name))
     elif args.action == "fetch_pdb":
         fetch_pdb(args.pdb_name, args.guid_age)
-    if args.action == "pdb_guid":
+    elif args.action == "pdb_guid":
         print(pdb_guid(args.file))
     else:
         raise RuntimeError('Unknown action')

--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -351,7 +351,7 @@ def pdb_guid(file):
     return {"filename": tmp.Filename, "GUID": guidstr}
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(description='drakpdb')
     parser.add_argument('action', type=str, help='one of: fetch_pdb (requires --pdb-name), parse_pdb (requires --pdb-name and --guid_age), pdb_guid (requires --file)')
     parser.add_argument('--pdb_name', type=str, help='name of pdb file without extension, e.g. ntkrnlmp')
@@ -368,3 +368,7 @@ if __name__ == "__main__":
         print(pdb_guid(args.file))
     else:
         raise RuntimeError('Unknown action')
+
+
+if __name__ == "__main__":
+    main()

--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -353,10 +353,10 @@ def pdb_guid(file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='drakpdb')
-    parser.add_argument('action', type=str, help='one of: fetch_pdb, parse_pdb, pdb_guid')
-    parser.add_argument('pdb_name', type=str, help='name of pdb file without extension, e.g. ntkrnlmp')
-    parser.add_argument('guid_age', nargs='?', help='guid/age of the pdb file')
-    parser.add_argument('file', type=str, help='file to get GUID age from')
+    parser.add_argument('action', type=str, help='one of: fetch_pdb (requires --pdb-name), parse_pdb (requires --pdb-name and --guid_age), pdb_guid (requires --file)')
+    parser.add_argument('--pdb_name', type=str, help='name of pdb file without extension, e.g. ntkrnlmp')
+    parser.add_argument('--guid_age', type=str, help='guid/age of the pdb file')
+    parser.add_argument('--file', type=str, help='file to get GUID age from')
 
     args = parser.parse_args()
 

--- a/drakrun/drakrun/py-scripts/drakpdb
+++ b/drakrun/drakrun/py-scripts/drakpdb
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from drakrun.drakpdb import main
+main()

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=["drakrun"],
     include_package_data=True,
     install_requires=open("requirements.txt").read().splitlines(),
-    scripts=['drakrun/py-scripts/drakrun', 'drakrun/py-scripts/draksetup', 'drakrun/py-scripts/drakpush'],
+    scripts=['drakrun/py-scripts/drakrun', 'drakrun/py-scripts/draksetup', 'drakrun/py-scripts/drakpush', 'drakrun/py-scripts/drakpdb'],
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Argument parsing in drakpdb is completely broken as per now, due to `file` argument being always required and a bug `if` vs `elif` when dispatching commands.