### PR TITLE
drakrun: delete contents of ipt directory when archiving

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -253,6 +253,7 @@ class DrakrunKarton(Karton):
         for root, dirs, files in os.walk(dirpath):
             for file in files:
                 zipf.write(os.path.join(root, file), os.path.join("ipt", os.path.relpath(os.path.join(root, file), dirpath)))
+                os.unlink(os.path.join(root, file))
 
     def upload_artifacts(self, analysis_uid, workdir, subdir=''):
         base_path = os.path.join(workdir, 'output')


### PR DESCRIPTION
Contents of `ipt` directory is not deleted after archived into a zip, thus we upload lots of small files into `ipt/` analysis subdirectory in MinIO. These files are redundant because they are already archived into `ipt.zip`