### PR TITLE
drakrun: enable fast singlestep

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -425,8 +425,8 @@ class DrakrunKarton(Karton):
 
                 drakvuf_cmd = ["drakvuf"] + self.generate_plugin_cmdline(task_quality) + \
                               ["-o", "json"
-                               # be aware of https://github.com/tklengyel/drakvuf/pull/951
-                               "-F", # enable fast singlestep
+                               #  be aware of https://github.com/tklengyel/drakvuf/pull/951
+                               "-F", #  enable fast singlestep
                                "-j", "5",
                                "-t", str(timeout),
                                "-i", str(self.runtime_info.inject_pid),

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -425,8 +425,8 @@ class DrakrunKarton(Karton):
 
                 drakvuf_cmd = ["drakvuf"] + self.generate_plugin_cmdline(task_quality) + \
                               ["-o", "json"
-                               #  be aware of https://github.com/tklengyel/drakvuf/pull/951
-                               "-F", #  enable fast singlestep
+                               # be aware of https://github.com/tklengyel/drakvuf/pull/951
+                               "-F",  # enable fast singlestep
                                "-j", "5",
                                "-t", str(timeout),
                                "-i", str(self.runtime_info.inject_pid),

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -425,6 +425,8 @@ class DrakrunKarton(Karton):
 
                 drakvuf_cmd = ["drakvuf"] + self.generate_plugin_cmdline(task_quality) + \
                               ["-o", "json"
+                               # be aware of https://github.com/tklengyel/drakvuf/pull/951
+                               "-F", # enable fast singlestep
                                "-j", "5",
                                "-t", str(timeout),
                                "-i", str(self.runtime_info.inject_pid),


### PR DESCRIPTION
Fast singlestep is disabled by default due to a bug that causes unexpected behavior when DRAKVUF is ran multiple times against the same VM. We are not affected because we always restore the VM from snapshot anyway :smarts:

Thus we can safely enable fast-singlestep and have faster singlestep.