### PR TITLE
drakcore: generate a file with TLS keys in Wireshark format

### DIFF
--- a/drakcore/drakcore/analysis.py
+++ b/drakcore/drakcore/analysis.py
@@ -46,6 +46,10 @@ class AnalysisProxy:
             f"{self.uid}/index/{log_type}",
             output_file.name)
 
+    def get_pcap_dump(self, output_file):
+        """ Download dump.pcap file. """
+        return self.minio.fget_object(self.bucket, f"{self.uid}/dump.pcap", output_file.name)
+
     def get_wireshark_key_file(self, output_file):
         """
         Download tls session keys in format that is accepted by wireshark.

--- a/drakcore/drakcore/analysis.py
+++ b/drakcore/drakcore/analysis.py
@@ -47,7 +47,7 @@ class AnalysisProxy:
             output_file.name)
 
     def get_wireshark_key_file(self, output_file):
-        """ 
+        """
         Download tls session keys in format that is accepted by wireshark.
         """
         return self.minio.fget_object(self.bucket, f"{self.uid}/wireshark_key_file.txt", output_file.name)

--- a/drakcore/drakcore/analysis.py
+++ b/drakcore/drakcore/analysis.py
@@ -46,6 +46,12 @@ class AnalysisProxy:
             f"{self.uid}/index/{log_type}",
             output_file.name)
 
+    def get_wireshark_key_file(self, output_file):
+        """ 
+        Download tls session keys in format that is accepted by wireshark.
+        """
+        return self.minio.fget_object(self.bucket, f"{self.uid}/wireshark_key_file.txt", output_file.name)
+
     def get_dumps(self, output_file):
         """ Download memory dumps """
         return self.minio.fget_object(self.bucket, f"{self.uid}/dumps.zip", output_file.name)

--- a/drakcore/drakcore/app.py
+++ b/drakcore/drakcore/app.py
@@ -154,6 +154,14 @@ def logindex(task_uid, log_type):
         return send_file(f.name)
 
 
+@app.route("/wireshark_key_file/<task_uid>")
+def wireshark_key_file(task_uid):
+    analysis = AnalysisProxy(minio, task_uid)
+    with NamedTemporaryFile() as f:
+        analysis.get_wireshark_key_file(f)
+        return send_file(f.name)
+
+
 @app.route("/dumps/<task_uid>")
 def dumps(task_uid):
     analysis = AnalysisProxy(minio, task_uid)

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -340,11 +340,11 @@ class AnalysisMain extends Component {
             </div>
             <div className="card">
               <a
-                href={`/wireshark_key_file/${this.analysisID}`}
+                href={`/pcap_dump/${this.analysisID}`}
                 className="btn btn-primary"
               >
                 <i className="mdi mdi-download mr-2"></i>
-                <span>Download wireshark key file</span>
+                <span>Download network traffic</span>
               </a>
             </div>
           </div>

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -339,7 +339,10 @@ class AnalysisMain extends Component {
               </a>
             </div>
             <div className="card">
-              <a href={`/wireshark_key_file/${this.analysisID}`} className="btn btn-primary">
+              <a
+                href={`/wireshark_key_file/${this.analysisID}`}
+                className="btn btn-primary"
+              >
                 <i className="mdi mdi-download mr-2"></i>
                 <span>Download wireshark key file</span>
               </a>

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -338,6 +338,12 @@ class AnalysisMain extends Component {
                 <span>Download dumps</span>
               </a>
             </div>
+            <div className="card">
+              <a href={`/wireshark_key_file/${this.analysisID}`} className="btn btn-primary">
+                <i className="mdi mdi-download mr-2"></i>
+                <span>Download wireshark key file</span>
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/drakcore/drakcore/postprocess/__init__.py
+++ b/drakcore/drakcore/postprocess/__init__.py
@@ -7,6 +7,7 @@ from drakcore.postprocess.log_index import generate_log_index
 from drakcore.postprocess.pstree import build_process_tree
 from drakcore.postprocess.slice_logs import slice_drakmon_logs
 from drakcore.postprocess.ipt_disasm import generate_ipt_disasm
+from drakcore.postprocess.wireshark_key_file_gen import generate_wireshark_key_file
 
 PostprocessPlugin = namedtuple("PostprocessPlugin", ('handler', 'required'))
 
@@ -22,6 +23,8 @@ REGISTERED_PLUGINS = [
     PostprocessPlugin(process_api_log, required=['apimon.log']),
     # yields process_tree.json
     PostprocessPlugin(build_process_tree, required=['procmon.log']),
+    # yields wireshark_key_file.txt
+    PostprocessPlugin(generate_wireshark_key_file, required=['tlsmon.log']),
 
     PostprocessPlugin(generate_ipt_disasm, required=['ipt.zip']),
 

--- a/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
+++ b/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
@@ -22,7 +22,7 @@ def gen_key_file_from_log(tlsmon_log):
         except json.JSONDecodeError as e:
             logging.warning(f"line cannot be parsed as JSON\n{e}")
             continue
-    return key_file_content
+    return key_file_content.encode()
 
 
 def generate_wireshark_key_file(task: Task, resources: Dict[str, RemoteResource], minio):

--- a/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
+++ b/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
@@ -1,0 +1,41 @@
+import json
+import os
+import logging
+from karton2 import Task, RemoteResource
+from typing import Dict
+from tempfile import NamedTemporaryFile
+
+
+
+
+def gen_key_file_from_log(tlsmon_log):
+    key_file_content = ''
+    for line in tlsmon_log:
+        try:
+            entry = json.loads(line)
+            client_random = entry['client_random']
+            master_key = entry['master_key']
+            key_file_entry = f'CLIENT_RANDOM {client_random} {master_key}\n'
+            key_file_content += key_file_entry
+        except KeyError:
+            logging.exception(f"JSON is missing a required field\n{line}")
+            continue
+        except json.JSONDecodeError as e:
+            logging.warning(f"line cannot be parsed as JSON\n{e}")
+            continue
+    key_file = NamedTemporaryFile(delete=False)
+    key_file.write(key_file_content.encode())
+    return key_file
+    
+    
+def generate_wireshark_key_file(task: Task, resources: Dict[str, RemoteResource], minio):
+    analysis_uid = task.payload['analysis_uid']
+
+    with resources['tlsmon.log'].download_temporary_file() as tlsmon_log:
+        key_file = gen_key_file_from_log(tlsmon_log)
+        size = key_file.tell()
+        key_file.seek(0)
+        minio.put_object('drakrun', f'{analysis_uid}/wireshark_key_file.txt', key_file, size)
+        yield 'wireshark_key_file.txt'
+        key_file.close()
+        os.unlink(key_file.name)

--- a/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
+++ b/drakcore/drakcore/postprocess/wireshark_key_file_gen.py
@@ -6,8 +6,6 @@ from typing import Dict
 from tempfile import NamedTemporaryFile
 
 
-
-
 def gen_key_file_from_log(tlsmon_log):
     key_file_content = ''
     for line in tlsmon_log:
@@ -26,8 +24,8 @@ def gen_key_file_from_log(tlsmon_log):
     key_file = NamedTemporaryFile(delete=False)
     key_file.write(key_file_content.encode())
     return key_file
-    
-    
+
+
 def generate_wireshark_key_file(task: Task, resources: Dict[str, RemoteResource], minio):
     analysis_uid = task.payload['analysis_uid']
 


### PR DESCRIPTION
Generates a file with session keys from tlsmon.log which is acceptable by Wireshark and can be loaded without any modification to decrypt tls traffic.

I'm open to suggestions about improving the design side of this pr.
![Screenshot from 2020-12-15 14-21-14](https://user-images.githubusercontent.com/26001306/102237344-dddb2100-3ef4-11eb-8bdd-6729ac399dcd.png)
