### PR TITLE
drakcore: improve drak-gen-ptxed

### DIFF
--- a/drakcore/drakcore/bin/drak-gen-ptxed
+++ b/drakcore/drakcore/bin/drak-gen-ptxed
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-from drakcore.postprocess.ipt_disasm import main
-main()
+from drakcore.postprocess.ipt_disasm import cmdline_main
+cmdline_main()

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -7,6 +7,7 @@ from functools import reduce
 from collections import defaultdict
 import subprocess
 import tempfile
+import logging
 
 from karton2 import Task, RemoteResource
 from typing import Dict
@@ -170,7 +171,7 @@ def cmdline_main():
     cr3_value = args.cr3_value
 
     ptxed_cmdline = main(analysis_dir, cr3_value)
-    
+
     if args.dry_run:
         print(ptxed_cmdline)
     else:

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -159,14 +159,20 @@ def generate_ipt_disasm(task: Task, resources: Dict[str, RemoteResource], minio)
         main(tmpdir, injected_cr3)
 
 
-if __name__ == "__main__":
+def cmdline_main():
     parser = argparse.ArgumentParser()
     parser.add_argument("analysis_dir", help="Analysis output directory")
     parser.add_argument("cr3_value", type=hexint, help="CR3 of process of interest")
+    parser.add_argument("--dry-run", action="store_true", default=False)
     args = parser.parse_args()
 
     analysis_dir = Path(args.analysis_dir)
     cr3_value = args.cr3_value
 
     ptxed_cmdline = main(analysis_dir, cr3_value)
-    print(ptxed_cmdline)
+    
+    if args.dry_run:
+        print(ptxed_cmdline)
+    else:
+        log.setLevel(logging.WARNING)
+        subprocess.run(ptxed_cmdline)

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import subprocess
 import tempfile
 import logging
+import sys
 
 from karton2 import Task, RemoteResource
 from typing import Dict
@@ -180,15 +181,15 @@ def cmdline_main():
         print(subprocess.list2cmdline(ptxed_cmdline))
         sys.exit(0)
 
-    filter_cmdline = [f'drak-ipt-filter {analysis_dir}/ipt/ipt_stream_vcpu{args.vcpu} {args.cr3_value}']
-    
-    if args.verbose:
-        filter_cmdline.append('pv')
-    
-    filter_cmdline.append(f'cat > {f.name}')
-
     with tempfile.NamedTemporaryFile() as f:
-        logging.info(f"Filtering IPT stream for CR3: {ars.cr3}")
+        filter_cmdline = [f'drak-ipt-filter {analysis_dir}/ipt/ipt_stream_vcpu{args.vcpu} {args.cr3_value}']
+
+        if args.verbose:
+            filter_cmdline.append('pv')
+
+        filter_cmdline.append(f'cat > {f.name}')
+
+        logging.info(f"Filtering IPT stream for CR3: {args.cr3}")
         subprocess.run(' | '.join(filter_cmdline), shell=True)
 
         logging.info("Generating trace disassembly")

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -124,8 +124,7 @@ def main(analysis_dir, cr3_value):
     ]
 
     log.info("IPT: Succesfully generated ptxed command line")
-    # TODO automatically call ptxed in the future(?)
-    return subprocess.list2cmdline(ptxed_cmdline)
+    return ptxed_cmdline
 
 
 def generate_ipt_disasm(task: Task, resources: Dict[str, RemoteResource], minio):
@@ -166,6 +165,9 @@ def cmdline_main():
     parser.add_argument("cr3_value", type=hexint, help="CR3 of process of interest")
     parser.add_argument("--dry-run", action="store_true", default=False)
     args = parser.parse_args()
+    
+    if not args.dry_run:
+        log.setLevel(logging.WARNING)
 
     analysis_dir = Path(args.analysis_dir)
     cr3_value = args.cr3_value
@@ -173,7 +175,6 @@ def cmdline_main():
     ptxed_cmdline = main(analysis_dir, cr3_value)
 
     if args.dry_run:
-        print(ptxed_cmdline)
+        print(subprocess.list2cmdline(ptxed_cmdline))
     else:
-        log.setLevel(logging.WARNING)
         subprocess.run(ptxed_cmdline)

--- a/drakcore/drakcore/postprocess/ipt_disasm.py
+++ b/drakcore/drakcore/postprocess/ipt_disasm.py
@@ -182,7 +182,7 @@ def cmdline_main():
         sys.exit(0)
 
     with tempfile.NamedTemporaryFile() as f:
-        filter_cmdline = [f'drak-ipt-filter {analysis_dir}/ipt/ipt_stream_vcpu{args.vcpu} {args.cr3_value}']
+        filter_cmdline = [f'drak-ipt-filter {analysis_dir}/ipt/ipt_stream_vcpu{args.vcpu} {args.cr3}']
 
         if args.verbose:
             filter_cmdline.append('pv')


### PR DESCRIPTION
One command to rule them all.

```
# drak-gen-ptxed --analysis . --vcpu 0 --cr3 0x23a4c000 --vcpu 0
```

and after few minutes it starts printing trace disassembly for vCPU 0 for process CR3=0x23a4c000