### PR TITLE
drakrun: Add playground

### DIFF
--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -1,0 +1,108 @@
+import argparse
+import tempfile
+import subprocess
+from pathlib import Path, PureWindowsPath as WinPath
+from IPython import embed
+
+from drakrun.networking import (
+    setup_vm_network,
+    start_dnsmasq,
+)
+from drakrun.vm import generate_vm_conf, VirtualMachine
+from drakrun.config import InstallInfo, PROFILE_DIR, ETC_DIR
+from drakrun.storage import get_storage_backend
+from drakrun.util import RuntimeInfo, graceful_exit
+from drakrun.injector import Injector
+from drakrun.draksetup import find_default_interface
+
+
+class DrakmonShell:
+    def __init__(self, vm_id: int, dns: str):
+        install_info = InstallInfo.load()
+        backend = get_storage_backend(install_info)
+
+        generate_vm_conf(install_info, vm_id)
+        self.vm = VirtualMachine(backend, vm_id)
+
+        with open(Path(PROFILE_DIR) / "runtime.json", 'r') as f:
+            self.runtime_info = RuntimeInfo.load(f)
+        self.desktop = WinPath(r"%USERPROFILE%") / "Desktop"
+
+        self.kernel_profile = Path(PROFILE_DIR) / "kernel.json"
+        self.injector = Injector(
+            self.vm.vm_name,
+            self.runtime_info,
+            self.kernel_profile,
+        )
+        setup_vm_network(vm_id, True, find_default_interface(), dns)
+
+    def drakvuf(self, plugins, timeout=60):
+        d = tempfile.TemporaryDirectory(prefix="drakvuf_")
+        workdir = Path(d.name)
+
+        log = open(workdir / "drakmon.log", "wb")
+
+        cmd = ["drakvuf"]
+        cmd.extend([
+            "-o", "json",
+            "F",
+            "-j", "5",
+            "-t", str(timeout),
+            "-i", str(self.runtime_info.inject_pid),
+            "-k", str(self.runtime_info.vmi_offsets.kpgd),
+            "-r", self.kernel_profile,
+            "-d", self.vm.vm_name,
+            "--dll-hooks-list", Path(ETC_DIR) / "hooks.txt",
+        ])
+
+        if "memdump" in plugins:
+            dumps = workdir / "dumps"
+            dumps.mkdir()
+            cmd.extend(["--memdump-dir", dumps])
+
+        if "ipt" in plugins:
+            ipt = workdir / "ipt"
+            ipt.mkdir()
+            cmd.extend(["--ipt-dir", ipt])
+
+        for chk in (["-a", plugin] for plugin in plugins):
+            cmd.extend(chk)
+
+        subprocess.run(cmd, stdout=log)
+
+        return d
+
+    def copy(self, local):
+        local = Path(local)
+        self.injector.write_file(local, self.desktop / local.name)
+
+    def run(self, cmd):
+        self.injector.create_process(cmd)
+
+    def __enter__(self):
+        self.vm.restore()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.vm.destroy()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='DRAKVUF Sandbox interactive shell')
+    parser.add_argument('vm_id', type=int, help='VM id you want to control')
+    parser.add_argument('--dns', default='8.8.8.8')
+
+    args = parser.parse_args()
+
+    with graceful_exit(start_dnsmasq(args.vm_id, args.dns)), \
+         DrakmonShell(args.vm_id, args.dns) as shell:
+        helpers = {
+            'copy': shell.copy,
+            'drakvuf': shell.drakvuf,
+            'vm': shell.vm
+        }
+        embed(banner='', user_ns=helpers, colors='neutral')
+
+
+if __name__ == "__main__":
+    main()

--- a/drakrun/drakrun/py-scripts/drakplayground
+++ b/drakrun/drakrun/py-scripts/drakplayground
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import drakrun.playground as playground
+
+playground.main()

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -11,3 +11,4 @@ dataclasses-json==0.5.1
 click==7.1.2
 oletools==0.55.1
 regex==2020.7.14
+ipython==7.9.0

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -17,7 +17,13 @@ setup(
     packages=["drakrun"],
     include_package_data=True,
     install_requires=open("requirements.txt").read().splitlines(),
-    scripts=['drakrun/py-scripts/drakrun', 'drakrun/py-scripts/draksetup', 'drakrun/py-scripts/drakpush', 'drakrun/py-scripts/drakpdb'],
+    scripts=[
+        'drakrun/py-scripts/drakrun',
+        'drakrun/py-scripts/draksetup',
+        'drakrun/py-scripts/drakpush',
+        'drakrun/py-scripts/drakpdb',
+        'drakrun/py-scripts/drakplayground',
+    ],
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Example session:
```
(env) root@xeniarz:~# python drakvuf-sandbox/playground.py
qemu-img: warning: Deprecated use of backing file without explicit backing format (detected format of qcow2)
Formatting '/var/lib/drakrun/volumes/vm-10.img', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=107374182400 backing_file=/var/lib/drakrun/volumes/vm-0.img backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
Loading new save file /var/lib/drakrun/volumes/snapshot.sav (new xl fmt info 0x3/0x0/1982)
 Savefile contains xl domain config in JSON format
Parsing config from /etc/drakrun/configs/vm-10.cfg
xc: info: Found x86 HVM domain from Xen 4.14
xc: info: Restoring domain
xc: info: Restore successful
xc: info: XenStore: mfn 0xfeffc, dom 0, evt 1
xc: info: Console: mfn 0xfefff, dom 0, evt 2
dnsmasq: started, version 2.83 DNS disabled
dnsmasq: compile time options: IPv6 GNU-getopt DBus no-UBus i18n IDN2 DHCP DHCPv6 no-Lua TFTP conntrack ipset auth nettlehash DNSSEC loop-detect inotify dumpfile
dnsmasq-dhcp: DHCP, IP range 10.13.10.100 -- 10.13.10.200, lease time 12h
dnsmasq-dhcp: DHCP, sockets bound exclusively to interface drak10
Python 3.7.3 (default, Jul 25 2020, 13:03:44)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: copy("/root/drakvuf-sandbox/test/test.exe")
DRAKVUF injector v0.8-git20210202110844+321dbd1-1 Copyright (C) 2014-2021 Tamas K Lengyel
VMI_ERROR: --vmi_read: access context version mismatch, please update your code

In [2]: drakvuf(["apimon", "syscalls"], timeout=30)
1612354495.002218 DRAKVUF v0.8-git20210202110844+321dbd1-1 Copyright (C) 2014-2021 Tamas K Lengyel
VMI_ERROR: --vmi_read: access context version mismatch, please update your code
Out[2]: <TemporaryDirectory '/tmp/drakvuf_wwll0j4i'>

In [3]: ! ls /tmp/drakvuf_wwll0j4i/
drakmon.log

In [4]: vm.restore()
qemu-img: warning: Deprecated use of backing file without explicit backing format (detected format of qcow2)
Formatting '/var/lib/drakrun/volumes/vm-10.img', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=107374182400 backing_file=/var/lib/drakrun/volumes/vm-0.img backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
Loading new save file /var/lib/drakrun/volumes/snapshot.sav (new xl fmt info 0x3/0x0/1982)
 Savefile contains xl domain config in JSON format
Parsing config from /etc/drakrun/configs/vm-10.cfg
xc: info: Found x86 HVM domain from Xen 4.14
xc: info: Restoring domain

```