### PR TITLE
drakrun: Add support for test analyses

### DIFF
--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -60,6 +60,17 @@ syscall_filter=
 ; special version of drakvuf-bundle is required
 enable_ipt=0
 
+; (advanced) Enable testing codepaths. Test sample artifacts will not be uploaded
+; to persistent storage. Their lifetime will be bound to karton tasks produced by drakrun
+; sample_testing=0
+;
+; (advanced) override Karton test filters for this service:
+; test_filters=[ { "type": "sample-test", "platform": "win32", }, { "type": "sample-test", "platform": "win64" }]
+
+; (advanced) override Karton test headers for this service:
+; test_headers={ "type": "analysis-test", "kind": "drakrun" }
+
+
 [drakvuf_plugins]
 ; list of enabled DRAKVUF plugins that are used by default,
 ; this can be overriden for particular karton's task quality value

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -338,7 +338,7 @@ class DrakrunKarton(Karton):
                     # If it's not a test run, put them into drakrun bucket
                     resource = LocalResource(name=res_name, bucket='drakrun', path=file_path)
                     resource._uid = object_name
-                yield self.upload_artifact(res_name, file_path)
+                yield resource
             elif os.path.isdir(file_path):
                 yield from self.upload_artifacts(analysis_uid, outdir, os.path.join(subdir, fn))
 

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -113,6 +113,22 @@ class DrakrunKarton(Karton):
         "kind": "drakrun",
     }
 
+    # Filters and headers used for testing sample analysis
+    DEFAULT_TEST_FILTERS = [
+        {
+            "type": "sample-test",
+            "platform": "win32",
+        },
+        {
+            "type": "sample-test",
+            "platform": "win64",
+        },
+    ]
+    DEFAULT_TEST_HEADERS = {
+        "type": "analysis-test",
+        "kind": "drakrun",
+    }
+
     def __init__(self, config: Config, instance_id: int):
         super().__init__(config)
 
@@ -160,6 +176,12 @@ class DrakrunKarton(Karton):
         cls.identity = config.get('identity', cls.DEFAULT_IDENTITY)
         cls.filters = load_json(config, 'filters') or cls.DEFAULT_FILTERS
         cls.headers = load_json(config, 'headers') or cls.DEFAULT_HEADERS
+        cls.test_headers = load_json(config, 'test_headers') or cls.DEFAULT_TEST_HEADERS
+
+        # If testing is enabled, add additional test filters from the configuration
+        # or fall back to hardcoded
+        if config.getboolean("sample_testing", fallback=False):
+            cls.filters.extend(load_json(config, 'test_filters') or cls.DEFAULT_TEST_FILTERS)
 
     @property
     def net_enable(self) -> bool:
@@ -169,6 +191,19 @@ class DrakrunKarton(Karton):
     def enable_ipt(self) -> bool:
         # TODO: Inconsistent naming - net_enable vs enable_ipt
         return self.config.config['drakrun'].getboolean('enable_ipt', fallback=False)
+
+    @property
+    def test_run(self) -> bool:
+        # If testing is disabled, it's not a test run
+        if not self.config.config['drakrun'].getboolean('sample_testing', fallback=False):
+            return False
+
+        # Check if task matches any test filter
+        for filtr in self.test_filters:
+            if self.current_task.matches_filters(filtr):
+                return True
+
+        return False
 
     @property
     def vm_name(self) -> str:
@@ -295,9 +330,15 @@ class DrakrunKarton(Karton):
             if os.path.isfile(file_path):
                 object_name = os.path.join(analysis_uid, subdir, fn)
                 res_name = os.path.join(subdir, fn)
-                resource = LocalResource(name=res_name, bucket='drakrun', path=file_path)
-                resource._uid = object_name
-                yield resource
+                if self.test_run:
+                    # If it's a test run upload artifacts to karton-managed bucket
+                    # They'll be cleaned up by karton-system
+                    resource = LocalResource(name=res_name, path=file_path)
+                else:
+                    # If it's not a test run, put them into drakrun bucket
+                    resource = LocalResource(name=res_name, bucket='drakrun', path=file_path)
+                    resource._uid = object_name
+                yield self.upload_artifact(res_name, file_path)
             elif os.path.isdir(file_path):
                 yield from self.upload_artifacts(analysis_uid, outdir, os.path.join(subdir, fn))
 
@@ -305,7 +346,11 @@ class DrakrunKarton(Karton):
         payload = {"analysis_uid": self.analysis_uid}
         payload.update(metadata)
 
-        headers = dict(self.headers)
+        if self.test_run:
+            headers = dict(self.test_headers)
+        else:
+            headers = dict(self.headers)
+
         headers["quality"] = quality
 
         task = Task(headers, payload=payload)


### PR DESCRIPTION
Testing for regressions in analysis should be an important part of the
development process. Currently, we have not way to determinte if we're
going in a good direction.

This patch adds a few knobs to enable testing samples.
New configuration variables
    sample_testing - enables / disables test code paths
    test_filters - overrides type of test tasks, default -
        type:sample-test platform:win32/64
    test_header - overrides output headers of test analyses, default -
        type:analysis-test kind:drakrun

Apart from new filters and new headers, artifacts generated from test
tasks will be managed by karton and not stored indefinitely.