### PR TITLE
drakrun: fix IPT support

### DIFF
--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -104,6 +104,8 @@ class UploadSample extends Component {
       "tlsmon",
       "windowmon",
       "wmimon",
+      "ipt",
+      "codemon",
     ];
 
     this.multiselectStyle = {
@@ -212,6 +214,14 @@ class UploadSample extends Component {
     this.setState({ enabledPlugins: enabledPlugins });
   }
 
+  displayPluginImplications(enabledPlugins) {
+    if (enabledPlugins.indexOf("ipt") !== -1 && enabledPlugins.indexOf("codemon") == -1) {
+      return <p class="text-muted">Using <code>ipt</code> plugin implies using <code>codemon</code>.</p>;
+    }
+
+    return <span />;
+  }
+
   render() {
     let error;
     if (this.state.error !== null) {
@@ -280,6 +290,7 @@ class UploadSample extends Component {
               onSelect={this.handlePluginsChange}
               onRemove={this.handlePluginsChange}
             />
+	    {this.displayPluginImplications(this.state.enabledPlugins)}
           </div>
           <div className="collapse" id="customOptions">
             <OptionalField

--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -215,8 +215,15 @@ class UploadSample extends Component {
   }
 
   displayPluginImplications(enabledPlugins) {
-    if (enabledPlugins.indexOf("ipt") !== -1 && enabledPlugins.indexOf("codemon") == -1) {
-      return <p class="text-muted">Using <code>ipt</code> plugin implies using <code>codemon</code>.</p>;
+    if (
+      enabledPlugins.indexOf("ipt") !== -1 &&
+      enabledPlugins.indexOf("codemon") == -1
+    ) {
+      return (
+        <p class="text-muted">
+          Using <code>ipt</code> plugin implies using <code>codemon</code>.
+        </p>
+      );
     }
 
     return <span />;
@@ -290,7 +297,7 @@ class UploadSample extends Component {
               onSelect={this.handlePluginsChange}
               onRemove={this.handlePluginsChange}
             />
-	    {this.displayPluginImplications(this.state.enabledPlugins)}
+            {this.displayPluginImplications(this.state.enabledPlugins)}
           </div>
           <div className="collapse" id="customOptions">
             <OptionalField

--- a/drakcore/drakcore/frontend/src/UploadSample.js
+++ b/drakcore/drakcore/frontend/src/UploadSample.js
@@ -217,7 +217,7 @@ class UploadSample extends Component {
   displayPluginImplications(enabledPlugins) {
     if (
       enabledPlugins.indexOf("ipt") !== -1 &&
-      enabledPlugins.indexOf("codemon") == -1
+      enabledPlugins.indexOf("codemon") === -1
     ) {
       return (
         <p class="text-muted">

--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -56,10 +56,6 @@ syscall_filter=
 ; (advanced) override Karton output headers for this service:
 ;   headers=[{"type": "analysis", "kind": "drakrun"}]
 
-; (advanced) (experimental) use Intel Processor Trace
-; special version of drakvuf-bundle is required
-enable_ipt=0
-
 ; (advanced) Enable testing codepaths. Test sample artifacts will not be uploaded
 ; to persistent storage. Their lifetime will be bound to karton tasks produced by drakrun
 ; sample_testing=0

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -162,6 +162,11 @@ class DrakrunKarton(Karton):
             plugin_list = self.active_plugins[quality]
 
         plugin_list = list(set(plugin_list) & set(enabled_plugins))
+
+        if "ipt" in plugin_list and "codemon" not in plugin_list:
+            self.log.info("Using ipt plugin implies using codemon")
+            plugin_list.append("codemon")
+
         return list(chain.from_iterable([["-a", plugin] for plugin in plugin_list]))
 
     @classmethod
@@ -425,12 +430,7 @@ class DrakrunKarton(Karton):
         kernel_profile = os.path.join(PROFILE_DIR, "kernel.json")
 
         task_quality = self.current_task.headers.get("quality", "high")
-        requested_plugins = set(self.current_task.payload.get("plugins", self.active_plugins['_all_']))
-
-        if "ipt" in requested_plugins:
-            requested_plugins.add("codemon")
-
-        requested_plugins = list(requested_plugins)
+        requested_plugins = self.current_task.payload.get("plugins", self.active_plugins['_all_'])
 
         drakvuf_cmd = ["drakvuf"] + self.generate_plugin_cmdline(task_quality, requested_plugins) + \
                       ["-o", "json",

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -445,6 +445,8 @@ class DrakrunKarton(Karton):
                        "--memdump-dir", dump_dir,
                        "--ipt-dir", ipt_dir,
                        "--codemon-dump-dir", ipt_dir,
+                       "--codemon-log-everything",
+                       "--codemon-analyse-system-dll-vad"
                        "-r", kernel_profile,
                        "-e", full_cmd,
                        "-c", cwd]

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -612,6 +612,8 @@ class DrakrunKarton(Karton):
 
         # Make sure dumps have a reasonable size
         self.crop_dumps(os.path.join(outdir, 'dumps'), os.path.join(outdir, 'dumps.zip'))
+
+        # Compress IPT traces, they're quite large however they compress well
         self.compress_ipt(os.path.join(outdir, 'ipt'), os.path.join(outdir, 'ipt.zip'))
 
         metadata['time_finished'] = int(time.time())

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -446,7 +446,7 @@ class DrakrunKarton(Karton):
                        "--ipt-dir", ipt_dir,
                        "--codemon-dump-dir", ipt_dir,
                        "--codemon-log-everything",
-                       "--codemon-analyse-system-dll-vad"
+                       "--codemon-analyse-system-dll-vad",
                        "-r", kernel_profile,
                        "-e", full_cmd,
                        "-c", cwd]


### PR DESCRIPTION
* remove `enable_ipt` from `config.ini`, IPT is just enabled by requesting activation of `ipt` plugin
* activating `ipt` implies activation of `codemon`
* provide appropriate switches for `codemon`