### PR TITLE
drakrun: increase injection timeout to 60 seconds

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -435,7 +435,7 @@ class DrakrunKarton(Karton):
                       ["-o", "json",
                        # be aware of https://github.com/tklengyel/drakvuf/pull/951
                        "-F",  # enable fast singlestep
-                       "-j", "5",
+                       "-j", "60",
                        "-t", str(timeout),
                        "-i", str(self.runtime_info.inject_pid),
                        "-k", hex(self.runtime_info.vmi_offsets.kpgd),


### PR DESCRIPTION
On Windows 10 there is a huge bloat of background processes which significantly delays the start of the target process. Injection succeeds but it waits till the new process is seen and it might go far behind the current 5 second time limit.

related #510