### PR TITLE
drakpdb: Fix profile generation for a few PDBs

### DIFF
--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -65,8 +65,11 @@ TYPE_ENUM_TO_VTYPE = {
     "T_32PUSHORT": ["Pointer", dict(target="unsigned short")],
     "T_32PVOID": ["Pointer", dict(target="Void")],
     "T_32PWCHAR": ["Pointer", dict(target="UnicodeString")],
+    "T_32PHRESULT": ["Pointer", dict(target="long")],
+    "T_64PINT4": ["Pointer", dict(target="long")],
     "T_64PLONG": ["Pointer", dict(target="long")],
     "T_64PQUAD": ["Pointer", dict(target="long long")],
+    "T_64PSHORT": ["Pointer", dict(target="short")],
     "T_64PRCHAR": ["Pointer", dict(target="unsigned char")],
     "T_64PUCHAR": ["Pointer", dict(target="unsigned char")],
     "T_64PWCHAR": ["Pointer", dict(target="String")],
@@ -74,6 +77,10 @@ TYPE_ENUM_TO_VTYPE = {
     "T_64PUQUAD": ["Pointer", dict(target="unsigned long long")],
     "T_64PUSHORT": ["Pointer", dict(target="unsigned short")],
     "T_64PVOID": ["Pointer", dict(target="Void")],
+    "T_64PREAL32": ["Pointer", dict(target="float")],
+    "T_64PREAL64": ["Pointer", dict(target="double")],
+    "T_64PUINT4": ["Pointer", dict(target="unsigned int")],
+    "T_64PHRESULT": ["Pointer", dict(target="long")],
     "T_BOOL08": ["unsigned char", {}],
     "T_CHAR": ["char", {}],
     "T_INT4": ["long", {}],
@@ -87,6 +94,7 @@ TYPE_ENUM_TO_VTYPE = {
     "T_SHORT": ["short", {}],
     "T_UCHAR": ["unsigned char", {}],
     "T_UINT4": ["unsigned long", {}],
+    "T_UINT8": ["unsigned long long", {}],
     "T_ULONG": ["unsigned long", {}],
     "T_UQUAD": ["unsigned long long", {}],
     "T_USHORT": ["unsigned short", {}],
@@ -228,6 +236,9 @@ def process_struct(struct_info):
 
     try:
         for struct in struct_info.fieldlist.substructs:
+            # try to access struct.offset and trigger
+            # an AttributeError if it's missing
+            _ = struct.offset
             ss[struct.name] = struct
     except AttributeError:
         pass

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -2,7 +2,9 @@ karton-core==4.2.0
 minio==5.0.7
 redis==3.5.3
 pefile==2019.4.18
-pdbparse==1.4
+# Use pdbparse from master branch
+# current release - 1.5 has troubles parsing some of the PDBs
+pdbparse @ git+https://github.com/moyix/pdbparse.git@b5b61793e4a457c43a5aef7a0499b959826b2c04
 construct==2.9.45
 requests==2.25.1
 tqdm==4.43.0


### PR DESCRIPTION
Both pdbparse 1.4 and 1.5 (latest release) have troubles parsing some of the PDBs:
  * Windows/System32/ole32.dll
  * Windows/SysWOW64/ole32.dll
  * Windows/System32/urlmon.dll
  * Windows/SysWOW64/urlmon.dll
  
The isssue seems to be resolved on the master branch. Add the specific
version to the requirements.txt and fix some of the issues that cause
the processing to fail on our side.