### PR TITLE
examples: Remove unused imports from consumer.py

### DIFF
--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -4,8 +4,7 @@ import os
 import argparse
 import tempfile
 
-from karton.core import Karton, Config, Task, DirectoryResource
-
+from karton.core import Karton, Config
 
 class DrakrunAnalysisConsumer(Karton):
     identity = "karton.drakrun.archiver"


### PR DESCRIPTION
DirectoryResource was removed and the example crashes on import.