### PR TITLE
drakcore: Bump msql to 1.2.2

### DIFF
--- a/drakcore/requirements.txt
+++ b/drakcore/requirements.txt
@@ -5,4 +5,4 @@ redis==3.5.3
 uwsgi==2.0.17.1
 minio==5.0.7
 colorama==0.4.3
-msql==1.2.1
+msql==1.2.2


### PR DESCRIPTION
1.2.1 has requirements that conflict with malduck 4.1.0