### PR TITLE
Disable WMIMON/json-combase in Drakrun (Analysis Failures)

### DIFF
--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -41,7 +41,7 @@ dll_file_list = [
     # DLL("Windows/System32/ole32.dll", "ole32_profile", "--json-ole32"),
     # DLL("Windows/SysWOW64/ole32.dll", "wow_ole32_profile", "--json-wow-ole32"),
     *dll_pair("ole32"),
-    DLL("Windows/System32/combase.dll", "combase_profile", "--json-combase"),
+    #DLL("Windows/System32/combase.dll", "combase_profile", "--json-combase"),
     DLL("Windows/Microsoft.NET/Framework/v4.0.30319/clr.dll", "clr_profile", "--json-clr"),
     DLL("Windows/Microsoft.NET/Framework/v2.0.50727/mscorwks.dll", "mscorwks_profile", "--json-mscorwks"),
     DLL("Windows/winsxs/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80/GdiPlus.dll", "gdiplus_profile", None),

--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -41,7 +41,7 @@ dll_file_list = [
     # DLL("Windows/System32/ole32.dll", "ole32_profile", "--json-ole32"),
     # DLL("Windows/SysWOW64/ole32.dll", "wow_ole32_profile", "--json-wow-ole32"),
     *dll_pair("ole32"),
-    #DLL("Windows/System32/combase.dll", "combase_profile", "--json-combase"),
+    DLL("Windows/System32/combase.dll", "combase_profile", None),
     DLL("Windows/Microsoft.NET/Framework/v4.0.30319/clr.dll", "clr_profile", "--json-clr"),
     DLL("Windows/Microsoft.NET/Framework/v2.0.50727/mscorwks.dll", "mscorwks_profile", "--json-mscorwks"),
     DLL("Windows/winsxs/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80/GdiPlus.dll", "gdiplus_profile", None),


### PR DESCRIPTION
Based on the comment `Don't use DRAKVUF arguments, they're used by wmimon which is compiled out`, we should comment out the `--json-combase` argument as it is part of the `WMIMON` plugin as well based on Drakvuf source code in `main.cpp` (https://github.com/tklengyel/drakvuf/blob/master/src/main.cpp#L249)

**WMIMON Plugin Arguments:**
```cpp
#ifdef ENABLE_PLUGIN_WMIMON
        "\t --json-mpr <path to json>\n"
        "\t                           The JSON profile for mpr.dll\n"
        "\t --json-ole32 <path to json>\n"
        "\t                           The JSON profile for ole32.dll\n"
        "\t --json-wow-ole32 <path to json>\n"
        "\t                           The JSON profile for SysWOW64/ole32.dll\n"
        "\t --json-combase <path to json>\n"
        "\t                           The JSON profile for combase.dll\n"
#endif
```

As it stands right now, the latest build for `drakrun` still has the `--json-combase` argument enabled, which causes all submissions for analysis to fail.

Anyone looking for a workaround for now, just edit the `/opt/lib/<python-version>/site-packages/drakrun/drakpdb.py` file and comment out the the line `DLL("Windows/System32/combase.dll", "combase_profile", "--json-combase"),`.

Once this is fixed, it maybe a good idea push a minor version bump/build.