### PR TITLE
scripts: bump_version regex fixup

### DIFF
--- a/scripts/bump_version.json
+++ b/scripts/bump_version.json
@@ -6,5 +6,5 @@
         "drakrun/drakrun/version.py": "__version__ = \"$VERSION\"",
         "docs/conf.py": "release = 'v$VERSION'"
     },
-    "regex": "(\\d+\\.\\d+\\.\\d+(?:-(post|dev|alpha|beta|rc)[0-9])?)"
+    "regex": "(\\d+\\.\\d+\\.\\d+(?:-(post|dev|alpha|beta|rc)[0-9]?)?)"
 }


### PR DESCRIPTION
Don't enforce digits at the end of version tags, e.g.:
-dev -alpha -beta