### PR TITLE
drakrun, drakcore: Check size of uploaded log file

### DIFF
--- a/drakcore/drakcore/process.py
+++ b/drakcore/drakcore/process.py
@@ -53,7 +53,11 @@ def with_logs(object_name):
                                         bucket="drakrun")
                     task_uid = self.current_task.payload.get('analysis_uid') or self.current_task.uid
                     res._uid = f"{task_uid}/{res.name}"
-                    res.upload(self.backend)
+
+                    # Karton rejects empty resources
+                    # Ensure that we upload it only when some data was actually generated
+                    if buffer.len > 0:
+                        res.upload(self.backend)
                 except Exception:
                     self.log.exception("Failed to upload analysis logs")
         return wrapper

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -87,7 +87,11 @@ def with_logs(object_name):
                                         bucket="drakrun")
                     task_uid = self.current_task.payload.get('override_uid') or self.current_task.uid
                     res._uid = f"{task_uid}/{res.name}"
-                    res.upload(self.backend)
+
+                    # Karton rejects empty resources
+                    # Ensure that we upload it only when some data was actually generated
+                    if buffer.len > 0:
+                        res.upload(self.backend)
                 except Exception:
                     self.log.exception("Failed to upload analysis logs")
         return wrapper


### PR DESCRIPTION
If analysis emits no logs while processing a task, uploading log file to
object store will fail - karton disallows empty resources.
Skip uploading when there's no data.

Generated stacktrace:
```
Traceback (most recent call last):
   File "/opt/venvs/drakcore/lib/python3.7/site-packages/drakcore/process.py", line 56, in wrapper
    res.upload(self.backend)
   File "/opt/venvs/drakcore/lib/python3.7/site-packages/karton/core/resource.py", line 322, in upload
    raise RuntimeError("Can't upload resource without content")
 RuntimeError: Can't upload resource without content
 ```