### PR TITLE
ci: Don't require lint checks for E2E testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -238,8 +238,6 @@ steps:
 node:
    purpose: e2e
 depends_on:
-- check-drakcore
-- check-drakrun
 - build-drakcore
 - build-drakrun
 - build-drakvuf-bundle


### PR DESCRIPTION
It's quite annoying when one has to fix flake checks to test if E2E is working