### PR TITLE
Enable running drakvuf without plugins from gui

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -168,6 +168,9 @@ class DrakrunKarton(Karton):
             plugin_list = self.active_plugins[quality]
 
         plugin_list = list(set(plugin_list) & set(enabled_plugins))
+        if len(plugin_list) == 0:
+            # Disable all plugins explicitly as all plugins are enabled by default.
+            return list(chain.from_iterable(["-x", plugin] for plugin in sorted(self.active_plugins["_all_"])))
 
         if "ipt" in plugin_list and "codemon" not in plugin_list:
             self.log.info("Using ipt plugin implies using codemon")


### PR DESCRIPTION
This is a small fix – currently when no plugins are selected from gui, the drakvuf will be spawned with all plugins enabled.