### PR TITLE
Gui view fix

### DIFF
--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -170,8 +170,8 @@ function AnalysisBehavioralGraph(props) {
   if (!graph) {
     return graph === null ? (
       <div>
-        (Behavioral graph was not generated, please check out "ProcDOT integration
-        (optional)" section of README to enable it.)
+        (Behavioral graph was not generated, please check out "ProcDOT
+        integration (optional)" section of README to enable it.)
       </div>
     ) : (
       <div>Loading graph...</div>
@@ -237,23 +237,26 @@ class AnalysisMain extends Component {
   }
 
   render() {
-    let behavioralGraph = <AnalysisBehavioralGraph analysisID={this.analysisID} />;
+    let behavioralGraph = (
+      <AnalysisBehavioralGraph analysisID={this.analysisID} />
+    );
 
     let simpleProcessTree = (
       <div className="card tilebox-one">
         <div className="card-body">
           <h5 className="card-title mb-0">Process tree</h5>
-          { this.state.processTree ?
-          <ProcessTree
-            tree={this.state.processTree}
-            expandPid={this.state.injectedPid}
-            analysisID={this.analysisID}
-          /> : "(Analysis must be run with procmon plugin enabled to generate process tree.)"
-          }
+          {this.state.processTree ? (
+            <ProcessTree
+              tree={this.state.processTree}
+              expandPid={this.state.injectedPid}
+              analysisID={this.analysisID}
+            />
+          ) : (
+            "(Analysis must be run with procmon plugin enabled to generate process tree.)"
+          )}
         </div>
       </div>
     );
-
 
     let metadata;
     if (this.state.metadata) {

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -170,7 +170,7 @@ function AnalysisBehavioralGraph(props) {
   if (!graph) {
     return graph === null ? (
       <div>
-        (Process tree was not generated, please check out "ProcDOT integration
+        (Behavioral graph was not generated, please check out "ProcDOT integration
         (optional)" section of README to enable it.)
       </div>
     ) : (
@@ -210,11 +210,15 @@ class AnalysisMain extends Component {
       this.setState({ logs: res_logs.data });
     }
 
-    const process_tree = await api.getProcessTree(this.analysisID);
-    const inject_log = await api.getLog(this.analysisID, "inject");
-    if (process_tree && inject_log) {
-      const injectedPid = inject_log.data["InjectedPid"];
-      this.setState({ processTree: process_tree.data, injectedPid });
+    try {
+      const process_tree = await api.getProcessTree(this.analysisID);
+      const inject_log = await api.getLog(this.analysisID, "inject");
+      if (process_tree && inject_log) {
+        const injectedPid = inject_log.data["InjectedPid"];
+        this.setState({ processTree: process_tree.data, injectedPid });
+      }
+    } catch (error) {
+      console.log(error);
     }
 
     const metadata = await api.getMetadata(this.analysisID);
@@ -235,21 +239,21 @@ class AnalysisMain extends Component {
   render() {
     let processTree = <AnalysisBehavioralGraph analysisID={this.analysisID} />;
 
-    let simpleProcessTree;
-    if (this.state.processTree) {
-      simpleProcessTree = (
-        <div className="card tilebox-one">
-          <div className="card-body">
-            <h5 className="card-title mb-0">Process tree</h5>
-            <ProcessTree
-              tree={this.state.processTree}
-              expandPid={this.state.injectedPid}
-              analysisID={this.analysisID}
-            />
-          </div>
+    let simpleProcessTree = (
+      <div className="card tilebox-one">
+        <div className="card-body">
+          <h5 className="card-title mb-0">Process tree</h5>
+          { this.state.processTree ?
+          <ProcessTree
+            tree={this.state.processTree}
+            expandPid={this.state.injectedPid}
+            analysisID={this.analysisID}
+          /> : "(Analysis must be run with procmon plugin enabled to generate process tree.)"
+          }
         </div>
-      );
-    }
+      </div>
+    );
+
 
     let metadata;
     if (this.state.metadata) {

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -237,7 +237,7 @@ class AnalysisMain extends Component {
   }
 
   render() {
-    let processTree = <AnalysisBehavioralGraph analysisID={this.analysisID} />;
+    let behavioralGraph = <AnalysisBehavioralGraph analysisID={this.analysisID} />;
 
     let simpleProcessTree = (
       <div className="card tilebox-one">
@@ -308,7 +308,7 @@ class AnalysisMain extends Component {
         <div className="card tilebox-one">
           <div className="card-body">
             <h5 className="card-title mb-0">Behavioral graph</h5>
-            {processTree}
+            {behavioralGraph}
           </div>
         </div>
 

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -168,6 +168,9 @@ class DrakrunKarton(Karton):
             plugin_list = self.active_plugins[quality]
 
         plugin_list = list(set(plugin_list) & set(enabled_plugins))
+        if len(plugin_list) == 0:
+            # Disable all plugins explicitly as all plugins are enabled by default.
+            return list(chain.from_iterable(["-x", plugin] for plugin in sorted(self.active_plugins["_all_"])))
 
         if "ipt" in plugin_list and "codemon" not in plugin_list:
             self.log.info("Using ipt plugin implies using codemon")


### PR DESCRIPTION
Analysis that was run without procmon plugin enabled will fail to load metadata – as it fails early in `componentDidMount`.