### PR TITLE
Enrich metadata with list of plugins that were used during analysis

### DIFF
--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -274,9 +274,11 @@ class AnalysisMain extends Component {
               {this.state.metadata.plugins ? (
                 <tr>
                   <td>Plugins</td>
-                  <td>{this.state.metadata.plugins.join(', ')}</td>
+                  <td>{this.state.metadata.plugins.join(", ")}</td>
                 </tr>
-              ): []}
+              ) : (
+                []
+              )}
               <tr>
                 <td>Started at</td>
                 <td>{formatTimestamp(this.state.metadata.time_started)}</td>

--- a/drakcore/drakcore/frontend/src/AnalysisMain.js
+++ b/drakcore/drakcore/frontend/src/AnalysisMain.js
@@ -271,6 +271,12 @@ class AnalysisMain extends Component {
                 <td>Start command</td>
                 <td>{this.state.metadata.start_command}</td>
               </tr>
+              {this.state.metadata.plugins ? (
+                <tr>
+                  <td>Plugins</td>
+                  <td>{this.state.metadata.plugins.join(', ')}</td>
+                </tr>
+              ): []}
               <tr>
                 <td>Started at</td>
                 <td>{formatTimestamp(this.state.metadata.time_started)}</td>

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -176,7 +176,6 @@ class DrakrunKarton(Karton):
         plugin_list = self.active_plugins["_all_"]
         if quality in self.active_plugins:
             plugin_list = self.active_plugins[quality]
-flake8 --ignore E402,F401,E501
         plugin_list = list(set(plugin_list) & set(requested_plugins))
 
         if "ipt" in plugin_list and "codemon" not in plugin_list:

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -176,14 +176,13 @@ class DrakrunKarton(Karton):
         plugin_list = self.active_plugins["_all_"]
         if quality in self.active_plugins:
             plugin_list = self.active_plugins[quality]
-
+flake8 --ignore E402,F401,E501
         plugin_list = list(set(plugin_list) & set(requested_plugins))
 
         if "ipt" in plugin_list and "codemon" not in plugin_list:
             self.log.info("Using ipt plugin implies using codemon")
             plugin_list.append("codemon")
         return plugin_list
-
 
     @classmethod
     def reconfigure(cls, config: Dict[str, str]):


### PR DESCRIPTION
At some point, we might start relying on this information. For example on the frontend side, we might first download metadata and then display ProcessTree/BehavioralGraph based on whether the `procmon` was enabled during analysis instead of using `try catch` as `if` statements.