### PR TITLE
draksetup: Create snapshot after usermode profiles

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -592,18 +592,6 @@ def postinstall(report, generate_usermode):
     with open(os.path.join(PROFILE_DIR, 'runtime.json'), 'w') as f:
         f.write(runtime_info.to_json(indent=4))
 
-    logging.info("Saving VM snapshot...")
-
-    # snapshot domain but don't destroy it, leave it in paused state
-    subprocess.check_output('xl save -p vm-0 ' + os.path.join(VOLUME_DIR, "snapshot.sav"), shell=True)
-    logging.info("Snapshot was saved succesfully.")
-
-    logging.info("Snapshotting persistent memory...")
-    storage_backend.snapshot_vm0_volume()
-
-    logging.info("Unpausing VM")
-    subprocess.check_output('xl unpause vm-0', shell=True)
-
     injector = Injector('vm-0', runtime_info, kernel_profile)
     if generate_usermode:
         try:
@@ -614,6 +602,15 @@ def postinstall(report, generate_usermode):
             logging.exception(e)
 
     subprocess.check_output('xl destroy vm-0', shell=True)
+
+    logging.info("Saving VM snapshot...")
+
+    # snapshot domain but don't destroy it, leave it in paused state
+    subprocess.check_output('xl save -p vm-0 ' + os.path.join(VOLUME_DIR, "snapshot.sav"), shell=True)
+    logging.info("Snapshot was saved succesfully.")
+
+    logging.info("Snapshotting persistent memory...")
+    storage_backend.snapshot_vm0_volume()
 
     if report:
         send_usage_report({


### PR DESCRIPTION
If we're using qcow2 storage, and vm-0 is still running after doing the snapshot,
later clones will become inconsistent with the memory state and may lead to crashes.