### PR TITLE
draksetup: Fix qcow2 handling

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -664,7 +664,7 @@ def create_missing_profiles():
         if not profile_exists(profile):
             try:
                 create_rekall_profile(injector, profile)
-            except Exception as e:
+            except Exception:
                 # silence per-dll errors
                 pass
 


### PR DESCRIPTION
qcow2 snapshot method is a noop. If we keep the VM running after
performing a state snapshot, the image may become dirty and inconsistent
with the data cached in the OS.

Change this behavior to:
1. Stop vm-0 as soon as possible
2. Use VM restore mechanism to generate usermode profiles