### PR TITLE
include drakrun tests in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,12 +40,6 @@ steps:
     - pip3 install flake8
     - pip3 install -r drakrun/requirements.txt
     - flake8 --extend-ignore=E501,E203 --max-line-length=88 drakrun/
-- name: run drakrun tests
-  image: python:3.8-buster
-  commands:
-    - pip3 install -r drakrun/drakrun/test/requirements.txt
-    - pip3 install ./drakrun
-    - pytest -v drakrun/drakrun/test/
 node:
    purpose: generic
 trigger:

--- a/drakrun/MANIFEST.in
+++ b/drakrun/MANIFEST.in
@@ -1,2 +1,3 @@
 include drakrun/cfg.template
 include drakrun/tools/*
+include drakrun/test/*

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,6 +44,7 @@ DRAKMON_DEPS = [
     "bridge-utils",
     "dnsmasq",
     "libmagic1",
+    "lvm2",
 ]
 
 DRAKVUF_DEPS = [
@@ -187,14 +188,3 @@ def karton_bucket(drakmon_vm):
             time.sleep(1.0)
 
     return None
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """ Dump logs if we're going to exit with an error """
-    if exitstatus == 0:
-        return
-
-    print("Testing finished with errors, collecting logs")
-    with Connection("testvm", config=FABRIC_CONFIG) as c:
-        for service in DRAKMON_SERVICES:
-            c.run(f"journalctl -u {service}")

--- a/test/test_drakrun.py
+++ b/test/test_drakrun.py
@@ -1,0 +1,29 @@
+import pytest
+
+@pytest.fixture(scope="session")
+def pytest_installed(drakmon_vm):
+    """ Ensure that pytest is installed """
+    drakmon_vm.run(". /opt/venvs/drakrun/bin/activate && pip install pytest==6.2.2 pytest-steps==1.7.3")
+
+@pytest.fixture(scope="session")
+def drakrun_test_dir(pytest_installed, drakmon_vm):
+    """ Find location of tests """
+    res = drakmon_vm.run(
+    """
+    . /opt/venvs/drakrun/bin/activate &&  \
+    python -c "import os; import drakrun.test.conftest; print(os.path.dirname(drakrun.test.conftest.__file__))"
+    """)
+
+    return res.stdout.strip()
+
+def test_lvm(drakmon_vm, drakrun_test_dir):
+    drakmon_vm.run(f". /opt/venvs/drakrun/bin/activate && pytest {drakrun_test_dir}/test_lvm.py")
+
+def test_util(drakmon_vm, drakrun_test_dir):
+    drakmon_vm.run(f". /opt/venvs/drakrun/bin/activate && pytest {drakrun_test_dir}/test_util.py")
+
+def test_network(drakmon_vm, drakrun_test_dir):
+    drakmon_vm.run(f". /opt/venvs/drakrun/bin/activate && pytest {drakrun_test_dir}/test_network.py")
+
+def test_vm(drakmon_vm, drakrun_test_dir):
+    drakmon_vm.run(f". /opt/venvs/drakrun/bin/activate && pytest {drakrun_test_dir}/test_vm.py")


### PR DESCRIPTION
* Change network ID in order to not collide with running drakrun service
* Run drakrun tests in E2E testing VM

This is not the sanest way to do this, but current CI setup is somewhat
limiting.