### PR TITLE
Stop relying on NtTerminateProcess in pstree

### DIFF
--- a/drakcore/drakcore/postprocess/pstree.py
+++ b/drakcore/drakcore/postprocess/pstree.py
@@ -189,19 +189,6 @@ def parse_nt_create_process_ex_entry(
     pstree.add_process(p)
 
 
-def parse_nt_terminate_process_entry(
-    pstree: ProcessTree, entry: Dict[str, Any]
-) -> None:
-    pid = entry["ExitPid"] if entry["ExitPid"] != 0 else entry["PID"]
-    p = pstree.get_single_process(
-        pid, float(entry["TimeStamp"]), float(entry["TimeStamp"])
-    )
-    if p is None:
-        # ExitProcess might call TerminateProcess twice, so maybe we had already marked it.
-        return
-    p.ts_to = float(entry["TimeStamp"])
-
-
 def parse_mm_clean_process_address_space_entry(
     pstree: ProcessTree, entry: Dict[str, Any]
 ) -> None:
@@ -236,9 +223,6 @@ def tree_from_log(file: TextIO) -> List[Dict[str, Any]]:
             elif "Method" in entry and entry["Method"] == "NtCreateProcessEx":
                 # Process has been created after the analysis started.
                 parse_nt_create_process_ex_entry(pstree, entry)
-            elif "Method" in entry and entry["Method"] == "NtTerminateProcess":
-                # Process has been terminated. This can be deleted once MmCleanProcessAddressSpace will be added to procmon.
-                parse_nt_terminate_process_entry(pstree, entry)
             elif "Method" in entry and entry["Method"] == "MmCleanProcessAddressSpace":
                 # Process has been terminated.
                 parse_mm_clean_process_address_space_entry(pstree, entry)


### PR DESCRIPTION
There is a small race when the process creates a child and terminates right after. This is due NtTerminateProcess not being accurate. In logs, it looks like the parent process has first terminated and only then spawned a child process.

**Requires drakvuf bump to [5291824](https://github.com/tklengyel/drakvuf/commit/52918240e7c6bf1c5f635978109809c26b8f549b)**

