### PR TITLE
Extract macros only from some office formats

### DIFF
--- a/drakrun/drakrun/sample_startup.py
+++ b/drakrun/drakrun/sample_startup.py
@@ -44,13 +44,14 @@ def get_office_file_startup_command(extension, file_path):
         return None
     start_command.extend(["/t", "%f"])
 
-    vbaparser = VBA_Parser(file_path)
-    if vbaparser.detect_vba_macros():
-        outer_macros = get_outer_nodes_from_vba_file(file_path)
-        if not outer_macros:
-            outer_macros = []
-        for outer_macro in outer_macros:
-            start_command.append(f"/m{outer_macro}")
+    if extension in ["docm", "dotm", "xls", "xlsm", "xltm", "pptx"]:
+        vbaparser = VBA_Parser(file_path)
+        if vbaparser.detect_vba_macros():
+            outer_macros = get_outer_nodes_from_vba_file(file_path)
+            if not outer_macros:
+                outer_macros = []
+            for outer_macro in outer_macros:
+                start_command.append(f"/m{outer_macro}")
 
     return subprocess.list2cmdline(start_command)
 

--- a/drakrun/drakrun/sample_startup.py
+++ b/drakrun/drakrun/sample_startup.py
@@ -44,7 +44,7 @@ def get_office_file_startup_command(extension, file_path):
         return None
     start_command.extend(["/t", "%f"])
 
-    if extension in ["docm", "dotm", "xls", "xlsm", "xltm", "pptx"]:
+    if file_type_allows_macros(extension):
         vbaparser = VBA_Parser(file_path)
         if vbaparser.detect_vba_macros():
             outer_macros = get_outer_nodes_from_vba_file(file_path)
@@ -83,6 +83,10 @@ def get_dll_startup_command(pe_data):
             return "rundll32 %f,#{}".format(export[0])
 
     return "regsvr32 /s %f"
+
+
+def file_type_allows_macros(extension):
+    return extension in ["docm", "dotm", "xls", "xlsm", "xltm", "pptx"]
 
 
 def is_office_word_file(extension):


### PR DESCRIPTION
Small fix as `VBA_Parser` throws an exception when constructed from a file that cannot contain macro.