### PR TITLE
drakrun: Add missing T_64PCHAR pdbparse base_types

### DIFF
--- a/drakrun/drakrun/drakpdb.py
+++ b/drakrun/drakrun/drakpdb.py
@@ -167,6 +167,7 @@ TYPE_ENUM_TO_VTYPE = {
     "T_64PSHORT": ["Pointer", dict(target="short")],
     "T_64PRCHAR": ["Pointer", dict(target="unsigned char")],
     "T_64PUCHAR": ["Pointer", dict(target="unsigned char")],
+    "T_64PCHAR": ["Pointer", dict(target="char")],
     "T_64PWCHAR": ["Pointer", dict(target="String")],
     "T_64PULONG": ["Pointer", dict(target="unsigned long")],
     "T_64PUQUAD": ["Pointer", dict(target="unsigned long long")],


### PR DESCRIPTION
Installation with Windows 10 x64 leads to the following error during
postinstall:

```
[2021-09-20 14:36:20,042][DEBUG] Parsing PDB into JSON profile...
[2021-09-20 14:36:21,678][DEBUG] stdout: {"Plugin": "inject", "TimeStamp": "1632141365.020867", "Status": "Success", "ProcessName": "C:\\Windows\\System32\\win32k.sys", "Arguments": "", "InjectedPid": 0, "InjectedTid": 0}

[2021-09-20 14:36:21,679][DEBUG] stderr: DRAKVUF injector v0.8-git20210807130654+d74df17-1 Copyright (C) 2014-2021 Tamas K Lengyel

[2021-09-20 14:36:21,679][DEBUG] rc: 0
[2021-09-20 14:36:21,679][DEBUG] Traceback (most recent call last):
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/draksetup.py", line 579, in create_rekall_profile
    profile = make_pdb_profile(
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 368, in make_pdb_profile
    struct_specs = {
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 368, in <dictcomp>
    struct_specs = {
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 327, in traverse_tree
    yield from traverse_tree([struct.index.utype], visited=visited)
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 311, in traverse_tree
    yield info.name, process_struct(info)
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 348, in process_struct
    typ = get_field_type_info(field)
  File "/opt/venvs/drakrun/lib/python3.8/site-packages/drakrun/drakpdb.py", line 295, in get_field_type_info
    return TYPE_ENUM_TO_VTYPE[str(field.index)]
KeyError: 'T_64PCHAR'

[2021-09-20 14:36:21,679][INFO] Deleted /var/lib/drakrun/profiles/amd64_win32k_profile
```

Adding the missing T_64PCHAR type to the enum makes installation succed.