### PR TITLE
drakrun: Add ipconfig release before renew

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -608,6 +608,9 @@ class DrakrunKarton(Karton):
             if self.net_enable:
                 self.log.info("Setting up network...")
                 injector.create_process(
+                    "cmd /C ipconfig /release >nul", wait=True, timeout=120
+                )
+                injector.create_process(
                     "cmd /C ipconfig /renew >nul", wait=True, timeout=120
                 )
 


### PR DESCRIPTION
When starting the VM the IP address is sometime the same as that of the vm-0. This blocks all internet connection.
Using ipconfig /release reassign correct address.