### PR TITLE
First restore VM playground, then start dnsmasq.

### DIFF
--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -145,9 +145,7 @@ def main():
         handlers=[logging.StreamHandler()],
     )
 
-    with graceful_exit(start_dnsmasq(args.vm_id, args.dns)), DrakmonShell(
-        args.vm_id, args.dns
-    ) as shell:
+    with DrakmonShell(args.vm_id, args.dns) as shell, graceful_exit(start_dnsmasq(args.vm_id, args.dns)):
         helpers = {
             "help": shell.help,
             "copy": shell.copy,

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -145,7 +145,9 @@ def main():
         handlers=[logging.StreamHandler()],
     )
 
-    with DrakmonShell(args.vm_id, args.dns) as shell, graceful_exit(start_dnsmasq(args.vm_id, args.dns)):
+    with DrakmonShell(args.vm_id, args.dns) as shell, graceful_exit(
+        start_dnsmasq(args.vm_id, args.dns)
+    ):
         helpers = {
             "help": shell.help,
             "copy": shell.copy,


### PR DESCRIPTION
Makes sure the virtual network adapters and bridges are set up _before_ dnsmasq is started, such that dnsmasq can bind to them.

Fixes #704 
