### PR TITLE
CI: use /build as SANDBOX_DIR in custom_bundle.sh

### DIFF
--- a/ci/custom_bundle.sh
+++ b/ci/custom_bundle.sh
@@ -22,8 +22,8 @@ fi
 SANDBOX_DIR=$1
 
 # Don't clobber local repository
-cp -ra $SANDBOX_DIR /repo-local
-SANDBOX_DIR=/repo-local
+cp -ra $SANDBOX_DIR /build
+SANDBOX_DIR=/build
 
 PATCH_DIR=$2
 XEN_DIR=$SANDBOX_DIR/drakvuf/xen


### PR DESCRIPTION
Right now, script uses `/repo-local` as a build target instead of `/build`. Drakvuf scripts aren't very configurable in that matter.

Tested in CERT.pl internal CI pipeline
