### PR TITLE
CI: Temporarily set download links to CDNs (minio.drakvuf.cert.pl is no longer a thing)

### DIFF
--- a/drakcore/debian/rules
+++ b/drakcore/debian/rules
@@ -13,7 +13,7 @@ build:
 	cp drakcore/config.dist.ini drakcore/config.ini
 	cp drakcore/uwsgi.dist.ini drakcore/uwsgi.ini
 	# Download minio
-	if [ ! -f drakcore/systemd/minio ] ; then wget -O drakcore/systemd/minio https://minio.drakvuf.cert.pl/static/minio ; fi
+	if [ ! -f drakcore/systemd/minio ] ; then wget -O drakcore/systemd/minio https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2021-08-05T22-01-19Z ; fi
 	chmod +x drakcore/systemd/minio
 
 override_dh_virtualenv:

--- a/drakrun/package/Dockerfile
+++ b/drakrun/package/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 RUN echo -ne '#!/bin/sh\nexit 0\n' > /bin/systemctl && chmod +x /bin/systemctl
 
 # Install drakvuf bundle for libvmi headers
-RUN wget -O drakvuf.deb "https://minio.drakvuf.cert.pl/static/bundle/$(lsb_release -cs)/drakvuf-bundle-0.8-git20210807130654+d74df17-1-generic.deb" && \
+RUN wget -O drakvuf.deb "https://github.com/tklengyel/drakvuf/releases/download/1.0/debian_10-slim_drakvuf-bundle-1.0-git20221220221439+068b10f-1-generic.deb" && \
     dpkg -i ./drakvuf.deb && \
     cd /opt && \
     git clone https://xenbits.xen.org/git-http/xtf.git && \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -113,8 +113,7 @@ def drakmon_setup():
     logging.info(f"VM {drakvuf_vm.identity} created.")
 
     logging.info("Waiting for VM to be alive...")
-    while not drakvuf_vm.is_alive():
-        time.sleep(0.5)
+    drakvuf_vm.wait_alive()
 
     with drakvuf_vm.connect_ssh() as ssh:
         for deb in (drakvuf_sandbox_debs + drakvuf_debs):
@@ -136,13 +135,11 @@ def drakmon_setup():
     logging.info("Rebooting...")
 
     # Wait until VM reboots
-    while drakvuf_vm.is_alive():
-        time.sleep(0.5)
+    drakvuf_vm.wait_alive()
 
     logging.info("VM went down")
 
-    while not drakvuf_vm.is_alive():
-        time.sleep(0.5)
+    drakvuf_vm.wait_alive()
 
     logging.info("VM back up")
 

--- a/test/vm-runner-client/vm_runner_client/client.py
+++ b/test/vm-runner-client/vm_runner_client/client.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import re
+import time
 import uuid
 
 import requests
@@ -73,13 +75,14 @@ class DrakvufVM:
         })
         response.raise_for_status()
 
-    def is_alive(self):
-        try:
-            # I'm not sure how we should close that
-            self.connect_tcp(22)
-            return True
-        except (OSError, ProxyError):
-            return False
+    def wait_alive(self):
+        for tries in range(30):
+            try:
+                self.connect_tcp(22).close()
+                return True
+            except (OSError, ProxyError) as e:
+                logging.info(f"Try [{tries+1}/30]: {str(e)}")
+                time.sleep(1)
 
     @staticmethod
     def get_vm_identity():


### PR DESCRIPTION
Actually we should get rid of embedding minio and downloading drakvuf-bundle/xtf explicitly during packaging.