### PR TITLE
CI: Let .deb install any dependencies it wants

### DIFF
--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -1,6 +1,5 @@
 import time
 import json
-import requests
 import pytest
 
 from utils import get_hypervisor_type, get_service_info, Drakcore

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,14 +1,5 @@
 import io
 import logging
-import os
-
-
-def getenv_list(key, default):
-    """Get list separated by spaces"""
-    items = os.getenv(key)
-    if items:
-        return items.split()
-    return default
 
 
 def apt_install(c, packages):


### PR DESCRIPTION
Defining dependencies explicitly in test suite actually doesn't work because they're bound to specific version/distribution (`debian:buster`). If we want to build .deb for multiple versions, we need to rely on dependencies written in package.