### PR TITLE
Use wscript to run files detected as vbe

### DIFF
--- a/drakrun/drakrun/sample_startup.py
+++ b/drakrun/drakrun/sample_startup.py
@@ -20,7 +20,7 @@ def get_sample_startup_command(extension, sample, file_path):
         start_command = "powershell.exe -executionpolicy bypass -File %f"
     elif is_office_file(extension):
         start_command = get_office_file_startup_command(extension, file_path)
-    elif extension in ["js", "jse", "vbs"]:
+    elif extension in ["js", "jse", "vbs", "vbe"]:
         start_command = "wscript.exe %f"
     elif extension in ["hta", "html", "htm"]:
         start_command = "mshta.exe %f"


### PR DESCRIPTION
Files detected as .vbe are often also runnable with wscript, for example 18b75005950d9e39a1eb5ce18453e23e00ddecb2ac941967686f8a27b2db9ef9.