### PR TITLE
Drop drakvuf to v0.8-backports version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install Drakvuf bundle
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          apt install -y /out/drakvuf-bundle*.deb
+          apt install -y -f /out/drakvuf-bundle*.deb
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Xen Test Framework
         working-directory: /opt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,13 +121,14 @@ jobs:
         name: Build Xen Test Framework
         working-directory: /opt
         run: |
+          apt update
+          apt install -y make pkg-config gcc libglib2.0-dev
           git clone https://xenbits.xen.org/git-http/xtf.git
           cd xtf
           git checkout bf1c4eb6cb52785cf539eb83752dfcecfe66c5d1
           make -j4
       - name: Build draksetup tools
         run: |
-          apt install -y make pkg-config gcc libglib2.0-dev
           cp -v /build/usr/lib/libvmi* /usr/lib/
           mkdir /usr/include/libvmi
           cp -v /build/usr/include/libvmi/* /usr/include/libvmi/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,6 @@ jobs:
         name: Build Xen Test Framework
         working-directory: /opt
         run: |
-          apt update
           apt install -y make pkg-config gcc libglib2.0-dev
           git clone https://xenbits.xen.org/git-http/xtf.git
           cd xtf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           sh drakvuf/package/depends.sh
           bash ci/build_bundle.sh "${{ matrix.distro }}:${{matrix.version}}"
           ls -r /out
-      - name: Cache Drakvuf bundle
+      - name: Save Drakvuf bundle cache
         id: cache-drakvuf-bundle-save
         uses: actions/cache/save@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,13 +91,14 @@ jobs:
           export DRAKVUF_COMMIT=$(git ls-tree HEAD drakvuf | awk '{ print $3 }')
           echo "Drakvuf commit is ${DRAKVUF_COMMIT}"
           echo "DRAKVUF_COMMIT=$DRAKVUF_COMMIT" >> $GITHUB_ENV
-      - name: Cache Drakvuf bundle
-        id: cache-drakvuf-bundle
-        uses: actions/cache@v3
+      - name: Restored cached Drakvuf bundle
+        id: cache-drakvuf-bundle-restore
+        uses: actions/cache/restore@v3
         with:
           path: |
             /out/drakvuf-bundle*.deb 
-            /opt/xtf/tests/example/test-hvm64-example
+            /out/usr/lib/libvmi*
+            /out/usr/include/libvmi/*
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Drakvuf bundle
@@ -106,6 +107,16 @@ jobs:
           cd /build
           sh drakvuf/package/depends.sh
           bash ci/build_bundle.sh "${{ matrix.distro }}:${{matrix.version}}"
+          ls -r /out
+      - name: Cache Drakvuf bundle
+        id: cache-drakvuf-bundle-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            /out/drakvuf-bundle*.deb 
+            /out/usr/lib/libvmi*
+            /out/usr/include/libvmi/*
+          key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Xen Test Framework
         working-directory: /opt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
         env:
           DRAKVUF_DEBS_PATH: "/debs"
           BASE_IMAGE: "${{ matrix.distro }}-${{ matrix.version_number }}-generic-amd64"
-          SNAPSHOT_VERSION: "win7-20230213"
+          SNAPSHOT_VERSION: "win7-20210922"
           MINIO_HOST: "192.168.100.1:8181"
           VM_RUNNER_API_URL: "http://127.0.0.1:8080"
           VM_SUFFIX: "${{ matrix.distro }}-${{ matrix.version_number }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,8 @@ jobs:
       - name: Install Drakvuf bundle
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          apt install -y -f /out/drakvuf-bundle*.deb
+          apt update
+          apt install -y /out/drakvuf-bundle*.deb
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Xen Test Framework
         working-directory: /opt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /out/drakvuf-bundle*.deb 
-            /out/xen-hypervisor*.deb
-            /opt/xtf/tests/example/test-hvm64-example
+            /out/drakvuf-bundle*.deb
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Drakvuf bundle
@@ -107,35 +105,11 @@ jobs:
           cd /build
           sh drakvuf/package/depends.sh
           bash ci/build_bundle.sh "${{ matrix.distro }}:${{matrix.version}}"
-      - name: Install Drakvuf bundle
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y /out/drakvuf-bundle*.deb
-      - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
-        name: Build Xen Test Framework
-        working-directory: /opt
-        run: |
-          git clone https://xenbits.xen.org/git-http/xtf.git
-          cd xtf
-          git checkout bf1c4eb6cb52785cf539eb83752dfcecfe66c5d1
-          make -j4
-      - name: Build draksetup tools
-        run: |
-          apt install -y make pkg-config gcc libglib2.0-dev
-          make -C ./drakrun/drakrun/tools
-          cp /opt/xtf/tests/example/test-hvm64-example ./drakrun/drakrun/tools/
       - uses: actions/upload-artifact@v3
         with:
           name: drakvuf-bundle-debs-${{ matrix.distro }}-${{ matrix.version }}
           path: |
-            /out/drakvuf-bundle*.deb 
-            /out/xen-hypervisor*.deb
-      - uses: actions/upload-artifact@v3
-        with:
-          name: draksetup-tools-${{ matrix.distro }}-${{ matrix.version }}
-          path: |
-            drakrun/drakrun/tools/*
+            /out/drakvuf-bundle*.deb
   package_drakcore:
     needs: [lint_drakcore, lint_drakcore_frontend]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /out/drakvuf-bundle*.deb
+            /out/drakvuf-bundle*.deb 
+            /opt/xtf/tests/example/test-hvm64-example
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Drakvuf bundle
@@ -105,11 +106,29 @@ jobs:
           cd /build
           sh drakvuf/package/depends.sh
           bash ci/build_bundle.sh "${{ matrix.distro }}:${{matrix.version}}"
+      - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
+        name: Build Xen Test Framework
+        working-directory: /opt
+        run: |
+          git clone https://xenbits.xen.org/git-http/xtf.git
+          cd xtf
+          git checkout bf1c4eb6cb52785cf539eb83752dfcecfe66c5d1
+          make -j4
+      - name: Build draksetup tools
+        run: |
+          apt install -y make pkg-config gcc libglib2.0-dev
+          make -C ./drakrun/drakrun/tools
+          cp /opt/xtf/tests/example/test-hvm64-example ./drakrun/drakrun/tools/
       - uses: actions/upload-artifact@v3
         with:
           name: drakvuf-bundle-debs-${{ matrix.distro }}-${{ matrix.version }}
           path: |
             /out/drakvuf-bundle*.deb
+      - uses: actions/upload-artifact@v3
+        with:
+          name: draksetup-tools-${{ matrix.distro }}-${{ matrix.version }}
+          path: |
+            drakrun/drakrun/tools/*
   package_drakcore:
     needs: [lint_drakcore, lint_drakcore_frontend]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,7 @@ jobs:
           make -j4
       - name: Build draksetup tools
         run: |
+          apt install -y libjson-c-dev
           cp -v /build/usr/lib/libvmi* /usr/lib/
           mkdir /usr/include/libvmi
           cp -v /build/usr/include/libvmi/* /usr/include/libvmi/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
             /build/usr/lib/libvmi*
             /build/usr/include/libvmi/*
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
-      - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
+      - if: ${{ steps.cache-drakvuf-bundle-restore.outputs.cache-hit != 'true' }}
         name: Build Drakvuf bundle
         run: |
           cp -ra . /build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
         with:
           path: |
             /out/drakvuf-bundle*.deb 
-            /out/usr/lib/libvmi*
-            /out/usr/include/libvmi/*
+            /build/usr/lib/libvmi*
+            /build/usr/include/libvmi/*
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Drakvuf bundle
@@ -114,8 +114,8 @@ jobs:
         with:
           path: |
             /out/drakvuf-bundle*.deb 
-            /out/usr/lib/libvmi*
-            /out/usr/include/libvmi/*
+            /build/usr/lib/libvmi*
+            /build/usr/include/libvmi/*
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
       - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
         name: Build Xen Test Framework
@@ -128,6 +128,9 @@ jobs:
       - name: Build draksetup tools
         run: |
           apt install -y make pkg-config gcc libglib2.0-dev
+          cp -v /build/usr/lib/libvmi* /usr/lib/
+          mkdir /usr/include/libvmi
+          cp -v /build/usr/include/libvmi/* /usr/include/libvmi/
           make -C ./drakrun/drakrun/tools
           cp /opt/xtf/tests/example/test-hvm64-example ./drakrun/drakrun/tools/
       - uses: actions/upload-artifact@v3

--- a/ci/build_bundle.sh
+++ b/ci/build_bundle.sh
@@ -7,7 +7,8 @@ source $SCRIPTPATH/build_utils.sh
 
 set -e
 
-INSTALL_PATH=/build/drakvuf/usr
+# Usage of /build as root is required by DRAKVUF's mkdeb script
+INSTALL_PATH=/build/usr
 mkdir -p $INSTALL_PATH
 
 # Build Xen
@@ -31,24 +32,12 @@ popd
 # Build dwarf2json
 pushd drakvuf/dwarf2json
 /usr/local/go/bin/go build
+mkdir -p /build/dwarf2json/
+mv dwarf2json /build/dwarf2json/
 popd
 
 # Package DRAKVUF
 pushd drakvuf
 mkdir /out
-
-# remove volatility3
-sed -i '/volatility3/d' ./package/mkdeb
-# change drakvuf build dir
-sed -i 's/\/build/\/build\/drakvuf/g' ./package/mkdeb
-
-DISTRO=$1
-DRAKVUFVERSION=$(./scripts/version.sh --dev)
-XENVERSION=$(./xen/version.sh --full ./xen/xen/Makefile)
-
-echo "DISTRO=$DISTRO"
-echo "DRAKVUFVERSION=$DRAKVUFVERSION"
-echo "XENVERSION=$XENVERSION"
-
-sh ./package/mkdeb "$DISTRO" "$DRAKVUFVERSION" "$XENVERSION"
+sh ./package/mkdeb
 popd

--- a/ci/build_utils.sh
+++ b/ci/build_utils.sh
@@ -34,10 +34,6 @@ function build_drakvuf() {
     export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig/"
     export LDFLAGS="-L$PREFIX/lib"
     export CFLAGS="-I$PREFIX/include"
-    # Use clang as compiler, otherwise stuff doesn't build
-    # with drakvuf xen_helpers breaking on -Werror-c++-compat
-    export CC=clang
-    export CXX=clang++
     autoreconf -vif
     ./configure --prefix=$PREFIX --enable-debug
     make -j$(nproc)

--- a/ci/custom_bundle.sh
+++ b/ci/custom_bundle.sh
@@ -63,7 +63,8 @@ function setup_repository () {
 echo "[+] Setting up repository"
 setup_repository
 
-INSTALL_PATH=/build/drakvuf/usr
+# Usage of /build as root is required by DRAKVUF's mkdeb script
+INSTALL_PATH=/build/usr
 mkdir -p $INSTALL_PATH
 
 echo "[+] Building Xen"
@@ -85,16 +86,13 @@ popd
 echo "[+] Building dwarf2json"
 pushd $SANDBOX_DIR/drakvuf/dwarf2json
 /usr/local/go/bin/go build
+mkdir -p /build/dwarf2json/
+mv dwarf2json /build/dwarf2json/
 popd
 
 echo "[+] Packaging DRAKVUF"
 mkdir -p /out
 pushd $SANDBOX_DIR/drakvuf
-
-# Remove volatility3
-sed -i '/volatility3/d' ./package/mkdeb
-# Change drakvuf build dir
-sed -i 's/\/build/\/build\/drakvuf/g' ./package/mkdeb
 
 sh ./package/mkdeb
 popd

--- a/drakrun/drakrun/injector.py
+++ b/drakrun/drakrun/injector.py
@@ -12,7 +12,39 @@ class Injector:
         self.kernel_profile = kernel_profile
         self.runtime_info = runtime_info
 
-    def _get_cmdline_generic(self, method: str, timeout: int) -> List[str]:
+    def _run_with_timeout(
+        self,
+        args: List[str],
+        timeout: int,
+        check: bool = False,
+        capture_output: bool = False,
+    ):
+        """
+        subprocess.run(timeout=...) kills process instead of sending SIGTERM after
+        reaching timeout. In our case, we want to let injector do a clean termination.
+        """
+        kwargs = {}
+        if capture_output:
+            kwargs["stdout"] = subprocess.PIPE
+            kwargs["stderr"] = subprocess.PIPE
+        with subprocess.Popen(args, **kwargs) as proc:
+            try:
+                outs, errs = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                proc.wait(timeout)
+                raise
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+            retcode = proc.poll()
+            if check and retcode:
+                raise subprocess.CalledProcessError(
+                    retcode, proc.args, output=outs, stderr=errs
+                )
+            return subprocess.CompletedProcess(proc.args, retcode, outs, errs)
+
+    def _get_cmdline_generic(self, method: str) -> List[str]:
         """Build base command line for all injection methods"""
         return [
             "injector",
@@ -28,30 +60,22 @@ class Injector:
             hex(self.runtime_info.vmi_offsets.kpgd),
             "-m",
             method,
-            "--timeout",
-            str(timeout),
         ]
 
-    def _get_cmdline_writefile(
-        self, local: str, remote: str, timeout: int = 60
-    ) -> List[str]:
-        cmd = self._get_cmdline_generic("writefile", timeout=timeout)
+    def _get_cmdline_writefile(self, local: str, remote: str) -> List[str]:
+        cmd = self._get_cmdline_generic("writefile")
         cmd.extend(["-e", remote])
         cmd.extend(["-B", local])
         return cmd
 
-    def _get_cmdline_readfile(
-        self, remote: str, local: str, timeout: int = 60
-    ) -> List[str]:
-        cmd = self._get_cmdline_generic("readfile", timeout=timeout)
+    def _get_cmdline_readfile(self, remote: str, local: str) -> List[str]:
+        cmd = self._get_cmdline_generic("readfile")
         cmd.extend(["-e", remote])
         cmd.extend(["-B", local])
         return cmd
 
-    def _get_cmdline_createproc(
-        self, exec_cmd: str, wait: bool = False, timeout: Optional[int] = None
-    ) -> List[str]:
-        cmd = self._get_cmdline_generic("createproc", timeout=timeout)
+    def _get_cmdline_createproc(self, exec_cmd: str, wait: bool = False) -> List[str]:
+        cmd = self._get_cmdline_generic("createproc")
         cmd.extend(["-e", exec_cmd])
         if wait:
             cmd.append("-w")
@@ -62,14 +86,10 @@ class Injector:
     ) -> subprocess.CompletedProcess:
         """
         Copy local file to the VM
-        we pass (timeout-5) to drakvuf to give it 5 seconds to finish its loop
         """
-        drakvuf_timeout = timeout - 5 if timeout > 5 else 0
-        injector_cmd = self._get_cmdline_writefile(
-            local_path, remote_path, timeout=drakvuf_timeout
-        )
-        return subprocess.run(
-            injector_cmd, stdout=subprocess.PIPE, timeout=timeout, check=True
+        injector_cmd = self._get_cmdline_writefile(local_path, remote_path)
+        return self._run_with_timeout(
+            injector_cmd, timeout=timeout, check=True, capture_output=True
         )
 
     def read_file(
@@ -77,23 +97,17 @@ class Injector:
     ) -> subprocess.CompletedProcess:
         """
         Copy VM file to local
-        we pass (timeout-5) to drakvuf to give it 5 seconds to finish its loop
         """
-        drakvuf_timeout = timeout - 5 if timeout > 5 else 0
-        injector_cmd = self._get_cmdline_readfile(
-            remote_path, local_path, timeout=drakvuf_timeout
+        injector_cmd = self._get_cmdline_readfile(remote_path, local_path)
+        return self._run_with_timeout(
+            injector_cmd, timeout=timeout, capture_output=True
         )
-        return subprocess.run(injector_cmd, timeout=timeout, capture_output=True)
 
     def create_process(
         self, cmdline: str, wait: bool = False, timeout: int = 60
     ) -> subprocess.CompletedProcess:
         """
         Create a process inside the VM with given command line
-        we pass (timeout-5) to drakvuf to give it 5 seconds to finish it's loop
         """
-        drakvuf_timeout = timeout - 5 if timeout != 0 else 0
-        injector_cmd = self._get_cmdline_createproc(
-            cmdline, wait=wait, timeout=drakvuf_timeout
-        )
-        return subprocess.run(injector_cmd, timeout=timeout, check=True)
+        injector_cmd = self._get_cmdline_createproc(cmdline, wait=wait)
+        return self._run_with_timeout(injector_cmd, timeout=timeout, check=True)

--- a/drakrun/drakrun/injector.py
+++ b/drakrun/drakrun/injector.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import List, Optional
+from typing import List
 
 from drakrun.util import RuntimeInfo
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,7 +39,6 @@ DRAKVUF_SANDBOX_DEBS = [
 
 DRAKVUF_DEBS = [
     "drakvuf-bundle-*.deb",
-    "xen-hypervisor-*.deb",
 ]
 
 


### PR DESCRIPTION
Drakvuf downgrade to last stable version that actually works on CERT.pl production setup.

After tests, drakvuf-sandbox has not been proven stable enough to work with Drakvuf v1.0, so we need to make a step back and then try once again. Changes before the downgrade are tracked on `drakvuf-v1.x` branch, so things applicable only to v1.0+ version can be still developed there.

**If you read this to roll it back to v1.0:**
- `.github/workflows/build.yml` changes should be OK for both versions, only SNAPSHOT_VERSION must be changed
- other changes can be simply reverted
