### PR TITLE
Change runtimeinfo parameter to path

### DIFF
--- a/drakrun/drakrun/config.py
+++ b/drakrun/drakrun/config.py
@@ -13,6 +13,7 @@ VM_CONFIG_DIR = os.path.join(ETC_DIR, "configs")
 
 LIB_DIR = os.getenv("DRAKRUN_LIB_DIR") or "/var/lib/drakrun"
 PROFILE_DIR = os.path.join(LIB_DIR, "profiles")
+RUNTIME_FILE = os.path.join(PROFILE_DIR, "runtime.json")
 APISCOUT_PROFILE_DIR = os.path.join(LIB_DIR, "apiscout_profile")
 VOLUME_DIR = os.path.join(LIB_DIR, "volumes")
 

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -28,6 +28,7 @@ from drakrun.config import (
     ETC_DIR,
     LIB_DIR,
     PROFILE_DIR,
+    RUNTIME_FILE,
     VM_CONFIG_DIR,
     VOLUME_DIR,
     InstallInfo,
@@ -807,8 +808,7 @@ def create_missing_profiles():
     """
 
     # Prepare injector
-    with open(os.path.join(PROFILE_DIR, "runtime.json"), "r") as runtime_f:
-        runtime_info = RuntimeInfo.load(runtime_f)
+    runtime_info = RuntimeInfo.load(RUNTIME_FILE)
     kernel_profile = os.path.join(PROFILE_DIR, "kernel.json")
     injector = Injector("vm-1", runtime_info, kernel_profile)
 

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -31,6 +31,7 @@ from drakrun.config import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
     PROFILE_DIR,
+    RUNTIME_FILE,
     VOLUME_DIR,
     InstallInfo,
 )
@@ -158,8 +159,7 @@ class DrakrunKarton(Karton):
             self.config.config["drakrun"].get("analysis_low_timeout")
             or self.default_timeout
         )
-        with open(os.path.join(PROFILE_DIR, "runtime.json"), "r") as runtime_f:
-            self.runtime_info = RuntimeInfo.load(runtime_f)
+        self.runtime_info = RuntimeInfo.load(RUNTIME_FILE)
 
         self.active_plugins = {}
         self.active_plugins["_all_"] = [

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 from IPython import embed
 
-from drakrun.config import ETC_DIR, PROFILE_DIR, InstallInfo
+from drakrun.config import ETC_DIR, PROFILE_DIR, RUNTIME_FILE, InstallInfo
 from drakrun.draksetup import find_default_interface, insert_cd
 from drakrun.injector import Injector
 from drakrun.networking import delete_vm_network, setup_vm_network, start_dnsmasq
@@ -29,8 +29,7 @@ class DrakmonShell:
         self.vm = VirtualMachine(backend, vm_id)
         self._dns = dns
 
-        with open(Path(PROFILE_DIR) / "runtime.json", "r") as f:
-            self.runtime_info = RuntimeInfo.load(f)
+        self.runtime_info = RuntimeInfo.load(RUNTIME_FILE)
         self.desktop = WinPath(r"%USERPROFILE%") / "Desktop"
 
         self.kernel_profile = Path(PROFILE_DIR) / "kernel.json"

--- a/drakrun/drakrun/test/test_util.py
+++ b/drakrun/drakrun/test/test_util.py
@@ -1,7 +1,7 @@
+import tempfile
 from io import StringIO
 
 import pytest
-import tempfile
 
 from drakrun.util import RuntimeInfo, VmiOffsets
 

--- a/drakrun/drakrun/test/test_util.py
+++ b/drakrun/drakrun/test/test_util.py
@@ -1,5 +1,4 @@
 import tempfile
-from io import StringIO
 
 import pytest
 

--- a/drakrun/drakrun/test/test_util.py
+++ b/drakrun/drakrun/test/test_util.py
@@ -1,6 +1,7 @@
 from io import StringIO
 
 import pytest
+import tempfile
 
 from drakrun.util import RuntimeInfo, VmiOffsets
 
@@ -67,5 +68,7 @@ def serialized_runtime_info(runtime_info):
 
 
 def test_runtime_info_load(serialized_runtime_info):
-    stream = StringIO(serialized_runtime_info)
-    RuntimeInfo.load(stream)
+    with tempfile.NamedTemporaryFile(mode="w") as temp:
+        temp.write(serialized_runtime_info)
+        temp.flush()
+        RuntimeInfo.load(temp.name)

--- a/drakrun/drakrun/util.py
+++ b/drakrun/drakrun/util.py
@@ -57,8 +57,9 @@ class RuntimeInfo:
     inject_pid: int
 
     @staticmethod
-    def load(file_obj: IO[AnyStr]) -> "RuntimeInfo":
-        return RuntimeInfo.from_json(file_obj.read())
+    def load(file_path: str) -> "RuntimeInfo":
+        with open(file_path) as file_obj:
+            return RuntimeInfo.from_json(file_obj.read())
 
 
 def patch_config(cfg):

--- a/drakrun/drakrun/util.py
+++ b/drakrun/drakrun/util.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 import traceback
 from dataclasses import dataclass, field
-from typing import IO, AnyStr
 
 from dataclasses_json import config, dataclass_json
 


### PR DESCRIPTION
There's some significant code duplication here, so I think it may be useful to unify it.

Unfortunately it adds lines of code instead of removing them because of new imports, but it's actually less code.