### PR TITLE
Remove config patching

### DIFF
--- a/drakrun/drakrun/config.dist.ini
+++ b/drakrun/drakrun/config.dist.ini
@@ -12,13 +12,8 @@ bucket=karton
 secure=0
 
 ; MinIO access credentials
-;
-; NOTE:
-; if this is empty, credentials will be read from /etc/drakcore/minio.env
-;
-; you only need to fill this out if you are:
-; * using external MinIO server
-; * using multi-node setup (drakcore is not on the same machine as drakrun)
+; If draksetup is run with --envfile option, these options will be imported
+; from the provided envfile (for example from /etc/drakcore/minio.env)
 access_key=
 secret_key=
 

--- a/drakrun/drakrun/drakpush.py
+++ b/drakrun/drakrun/drakpush.py
@@ -4,7 +4,6 @@ import os
 from karton.core import Config, Producer, Resource, Task
 
 from drakrun.config import ETC_DIR
-from drakrun.util import patch_config
 
 
 def main():
@@ -24,8 +23,7 @@ def main():
     )
     args = parser.parse_args()
 
-    conf = patch_config(Config(os.path.join(ETC_DIR, "config.ini")))
-    producer = Producer(conf)
+    producer = Producer(Config(os.path.join(ETC_DIR, "config.ini")))
 
     task = Task({"type": "sample", "stage": "recognized", "platform": "win32"})
 

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 import traceback
 from pathlib import Path, PureWindowsPath
+from typing import Dict
 
 import click
 from minio import Minio

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -1326,16 +1326,16 @@ def init(envfile: str):
     # Simple activities handled by deb packages before
     # In the future, consider splitting this to remove hard dependency on systemd etc
     Path(ETC_DIR).mkdir(exist_ok=True)
-    config_data = (Path(__file__).parent / "config.dist.ini").read_text()
+    config = (Path(__file__).parent / "config.dist.ini").read_text()
 
     # This feature is provided for compatibility with minio.env files, but we plan to
     # remove it in the future.
     if envfile:
         env = parse_envfile(envfile)
-        config_data.replace("access_key=", f"access_key={env['MINIO_ACCESS_KEY']}")
-        config_data.replace("secret_key=", f"secret_key={env['MINIO_SECRET_KEY']}")
+        config = config.replace("access_key=", f"access_key={env['MINIO_ACCESS_KEY']}")
+        config = config.replace("secret_key=", f"secret_key={env['MINIO_SECRET_KEY']}")
 
-    (Path(ETC_DIR) / "config.ini").write_text(config_data)
+    (Path(ETC_DIR) / "config.ini").write_text(config)
 
     default_hooks = (Path(__file__).parent / "hooks.dist.txt").read_text()
     (Path(ETC_DIR) / "hooks.txt").write_text(default_hooks)

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -1315,16 +1315,12 @@ def do_import_full(mc, name, bucket, zpool):
 
 def parse_envfile(path: str) -> Dict[str, str]:
     with open(path, "r") as f:
-        cfg = [
-            line.strip().split("=", 1) for line in f if line.strip() and "=" in line
-        ]
+        cfg = [line.strip().split("=", 1) for line in f if line.strip() and "=" in line]
     return {k: v for k, v in cfg}
 
 
 @click.command(help="Pre-installation activities")
-@click.option(
-    "--envfile", default="", help="Import s3 config from this file"
-)
+@click.option("--envfile", default="", help="Import s3 config from this file")
 def init(envfile: str):
     # Simple activities handled by deb packages before
     # In the future, consider splitting this to remove hard dependency on systemd etc

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -44,7 +44,6 @@ from drakrun.util import (
     get_xen_commandline,
     get_xl_info,
     graceful_exit,
-    patch_config,
 )
 from drakrun.version import __version__ as DRAKRUN_VERSION
 from drakrun.vm import VirtualMachine, generate_vm_conf
@@ -864,7 +863,7 @@ def cmdline_main():
 
 def main(args):
     conf_path = os.path.join(ETC_DIR, "config.ini")
-    conf = patch_config(Config(conf_path))
+    conf = Config(conf_path)
 
     if not conf.config.get("minio", "access_key").strip():
         logging.warning(

--- a/drakrun/drakrun/regression.py
+++ b/drakrun/drakrun/regression.py
@@ -16,7 +16,6 @@ from mwdblib import MWDB
 from tqdm import tqdm
 
 from drakrun.config import ETC_DIR
-from drakrun.util import patch_config
 from drakrun.version import __version__ as DRAKRUN_VERSION
 
 
@@ -129,9 +128,7 @@ class RegressionTester(Karton):
     @classmethod
     def main(cls):
         conf_path = os.path.join(ETC_DIR, "config.ini")
-        config = patch_config(Config(conf_path))
-
-        consumer = RegressionTester(config)
+        consumer = RegressionTester(Config(conf_path))
 
         if not consumer.backend.minio.bucket_exists("draktestd"):
             consumer.backend.minio.make_bucket(bucket_name="draktestd")
@@ -158,7 +155,7 @@ class RegressionTester(Karton):
         args = parser.parse_args()
 
         conf_path = os.path.join(ETC_DIR, "config.ini")
-        config = patch_config(Config(conf_path))
+        config = Config(conf_path)
 
         with open(args.tests) as tests:
             testcases = [TestCase(**case) for case in json.load(tests)]

--- a/drakrun/drakrun/util.py
+++ b/drakrun/drakrun/util.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import traceback
 from dataclasses import dataclass, field
 
@@ -59,39 +58,6 @@ class RuntimeInfo:
     def load(file_path: str) -> "RuntimeInfo":
         with open(file_path) as file_obj:
             return RuntimeInfo.from_json(file_obj.read())
-
-
-def patch_config(cfg):
-    try:
-        access_key = cfg.config["minio"]["access_key"]
-        secret_key = cfg.config["minio"]["secret_key"]
-    except KeyError:
-        sys.stderr.write(
-            "WARNING! Misconfiguration: section [minio] of config.ini doesn't contain access_key or secret_key.\n"
-        )
-        return cfg
-
-    if not access_key and not secret_key:
-        if not os.path.exists("/etc/drakcore/minio.env"):
-            raise RuntimeError(
-                "ERROR! MinIO access credentials are not configured (and can not be auto-detected), unable to start.\n"
-            )
-
-        with open("/etc/drakcore/minio.env", "r") as f:
-            minio_cfg = [
-                line.strip().split("=", 1) for line in f if line.strip() and "=" in line
-            ]
-            minio_cfg = {k: v for k, v in minio_cfg}
-
-        try:
-            cfg.config["minio"]["access_key"] = minio_cfg["MINIO_ACCESS_KEY"]
-            cfg.config["minio"]["secret_key"] = minio_cfg["MINIO_SECRET_KEY"]
-        except KeyError:
-            sys.stderr.write(
-                "WARNING! Misconfiguration: minio.env doesn't contain MINIO_ACCESS_KEY or MINIO_SECRET_KEY.\n"
-            )
-
-    return cfg
 
 
 def get_domid_from_instance_id(instance_id: int) -> int:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -136,7 +136,7 @@ EOF""")
         # Import snapshot
         assert SNAPSHOT_VERSION is not None
         ssh.run(f"draksetup snapshot import --bucket snapshots --name {SNAPSHOT_VERSION} --full")
-        ssh.run(f"draksetup init")
+        ssh.run(f"draksetup init --envfile /etc/drakcore/minio.env")
 
         # Shut up QEMU
         ssh.run("ln -s /dev/null /root/SW_DVD5_Win_Pro_7w_SP1_64BIT_Polish_-2_MLF_X17-59386.ISO")


### PR DESCRIPTION
By default karton config is patched every time after loading with contents from "/etc/drakcore/minio.env". Remove this feature.