### PR TITLE
Log within correct logging hierarchy

### DIFF
--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -1016,9 +1016,7 @@ def memdump():
 def memdump_export(bucket, instance):
     install_info = InstallInfo.try_load()
     if install_info is None:
-        log.error(
-            "Missing installation info. Did you forget to set up the sandbox?"
-        )
+        log.error("Missing installation info. Did you forget to set up the sandbox?")
         return
 
     backend = get_storage_backend(install_info)
@@ -1089,9 +1087,7 @@ def snapshot():
 def snapshot_export(name, bucket, full, force):
     install_info = InstallInfo.try_load()
     if install_info is None:
-        log.error(
-            "Missing installation info. Did you forget to set up the sandbox?"
-        )
+        log.error("Missing installation info. Did you forget to set up the sandbox?")
         return
 
     mc = get_minio_client(conf)
@@ -1187,9 +1183,7 @@ def snapshot_import(name, bucket, full, zpool):
                 return
 
             log.info("Minimal snapshots require postinstall to work correctly")
-            log.info(
-                "Please VNC to the port 5900 to ensure the OS booted correctly"
-            )
+            log.info("Please VNC to the port 5900 to ensure the OS booted correctly")
             log.info("After that, execute this command to finish the setup")
             log.info("# draksetup postinstall")
     except NoSuchKey:

--- a/drakrun/drakrun/networking.py
+++ b/drakrun/drakrun/networking.py
@@ -124,12 +124,12 @@ def setup_vm_network(
         subprocess.check_output(
             f"brctl addbr drak{vm_id}", stderr=subprocess.STDOUT, shell=True
         )
-        logging.info(f"Created bridge drak{vm_id}")
+        log.info(f"Created bridge drak{vm_id}")
     except subprocess.CalledProcessError as e:
         if b"already exists" in e.output:
             log.info(f"Bridge drak{vm_id} already exists.")
         else:
-            logging.debug(e.output)
+            log.debug(e.output)
             raise Exception(f"Failed to create bridge drak{vm_id}.")
     else:
         subprocess.run(
@@ -137,7 +137,7 @@ def setup_vm_network(
         )
 
     subprocess.run(f"ip link set dev drak{vm_id} up", shell=True, check=True)
-    logging.info(f"Bridge drak{vm_id} is up")
+    log.info(f"Bridge drak{vm_id} is up")
 
     add_iptable_rule(
         f"INPUT -i drak{vm_id} -p udp --dport 67:68 --sport 67:68 -j ACCEPT"
@@ -167,16 +167,16 @@ def delete_vm_network(vm_id, net_enable, out_interface, dns_server) -> None:
         subprocess.check_output(
             f"ip link set dev drak{vm_id} down", shell=True, stderr=subprocess.STDOUT
         )
-        logging.info(f"Bridge drak{vm_id} is down")
+        log.info(f"Bridge drak{vm_id} is down")
     except subprocess.CalledProcessError as e:
         if b"Cannot find device" in e.output:
             log.info(f"Already deleted drak{vm_id} bridge")
         else:
-            logging.debug(e.output)
+            log.debug(e.output)
             raise Exception(f"Couldn't deactivate drak{vm_id} bridge")
     else:
         subprocess.run(f"brctl delbr drak{vm_id}", stderr=subprocess.STDOUT, shell=True)
-        logging.info(f"Deleted drak{vm_id} bridge")
+        log.info(f"Deleted drak{vm_id} bridge")
 
     del_iptable_rule(
         f"INPUT -i drak{vm_id} -p udp --dport 67:68 --sport 67:68 -j ACCEPT"

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -16,6 +16,8 @@ from drakrun.storage import get_storage_backend
 from drakrun.util import RuntimeInfo, graceful_exit
 from drakrun.vm import FIRST_CDROM_DRIVE, VirtualMachine, generate_vm_conf
 
+log = logging.getLogger(__name__)
+
 
 class DrakmonShell:
     def __init__(self, vm_id: int, dns: str):
@@ -42,7 +44,7 @@ class DrakmonShell:
 
     def cleanup(self, vm_id: int):
 
-        logging.info(f"Ensuring that drakrun@{vm_id} service is stopped...")
+        log.info(f"Ensuring that drakrun@{vm_id} service is stopped...")
         try:
             subprocess.run(
                 ["systemctl", "stop", f"drakrun@{vm_id}"],

--- a/drakrun/drakrun/sample_startup.py
+++ b/drakrun/drakrun/sample_startup.py
@@ -6,7 +6,7 @@ from oletools.olevba import VBA_Parser
 
 from drakrun.vba_graph import get_outer_nodes_from_vba_file
 
-log = logging.getLogger("drakrun")
+log = logging.getLogger(__name__)
 
 
 def get_sample_startup_command(extension, sample, file_path):

--- a/drakrun/drakrun/storage.py
+++ b/drakrun/drakrun/storage.py
@@ -11,6 +11,8 @@ from typing import Tuple
 from drakrun.config import VOLUME_DIR, InstallInfo
 from drakrun.util import safe_delete
 
+log = logging.getLogger(__name__)
+
 
 class StorageBackendBase:
     """Base class for all storage backends
@@ -180,22 +182,22 @@ class ZfsStorageBackend(StorageBackendBase):
     def delete_vm_volume(self, vm_id: int):
         vm_id_vol = os.path.join(self.zfs_tank_name, f"vm-{vm_id}")
         try:
-            logging.info(f"Deleting zfs volume {vm_id_vol}")
+            log.info(f"Deleting zfs volume {vm_id_vol}")
             subprocess.check_output(
                 ["zfs", "destroy", "-Rfr", vm_id_vol], stderr=subprocess.STDOUT
             )
         except subprocess.CalledProcessError as exc:
-            logging.error(exc.stdout)
+            log.error(exc.stdout)
             raise Exception(f"Couldn't delete {vm_id_vol}")
 
     def delete_zfs_tank(self):
         try:
-            logging.info("Deleting zfs tank")
+            log.info("Deleting zfs tank")
             subprocess.run(
                 ["zfs", "destroy", "-r", f"{self.zfs_tank_name}"], check=True
             )
         except subprocess.CalledProcessError as exc:
-            logging.error(exc.stdout)
+            log.error(exc.stdout)
             raise Exception(f"Couldn't delete {self.zfs_tank_name}")
 
 
@@ -310,7 +312,7 @@ class LvmStorageBackend(StorageBackendBase):
         disk_size - string representing volume size with M/G/T suffix, eg. 100G
         """
         try:
-            logging.info("Deleting existing logical volume and snapshot")
+            log.info("Deleting existing logical volume and snapshot")
             subprocess.check_output(
                 [
                     "lvremove",
@@ -327,7 +329,7 @@ class LvmStorageBackend(StorageBackendBase):
                     f"Failed to destroy logical volume {self.lvm_volume_group}/vm-0"
                 )
         try:
-            logging.info("Creating new volume vm-0")
+            log.info("Creating new volume vm-0")
             subprocess.run(
                 [
                     "lvcreate",
@@ -365,7 +367,7 @@ class LvmStorageBackend(StorageBackendBase):
                 stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as exc:
-            logging.debug(exc.output)
+            log.debug(exc.output)
             raise RuntimeError("Couldn't create snapshot")
 
     def get_vm_disk_path(self, vm_id: int) -> str:
@@ -379,7 +381,7 @@ class LvmStorageBackend(StorageBackendBase):
         if vm_id == 0:
             raise Exception("vm-0 should not be rollbacked")
 
-        logging.info(f"Rolling back changes to vm-{vm_id} disk")
+        log.info(f"Rolling back changes to vm-{vm_id} disk")
         if os.path.exists(vm_id_vol):
             try:
                 subprocess.check_output(
@@ -393,7 +395,7 @@ class LvmStorageBackend(StorageBackendBase):
                     stderr=subprocess.STDOUT,
                 )
             except subprocess.CalledProcessError as exc:
-                logging.debug(exc.output)
+                log.debug(exc.output)
                 raise RuntimeError(
                     f"Failed to discard previous logical volume {self.lvm_volume_group}/vm-{vm_id}"
                 )
@@ -412,7 +414,7 @@ class LvmStorageBackend(StorageBackendBase):
                 stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as exc:
-            logging.debug(exc.output)
+            log.debug(exc.output)
             raise RuntimeError("Couldn't rollback disk")
 
     def get_vm0_snapshot_time(self):
@@ -479,7 +481,7 @@ class LvmStorageBackend(StorageBackendBase):
                 stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
-            logging.debug(e.output)
+            log.debug(e.output)
             raise Exception("Could not delete volume")
 
 

--- a/drakrun/drakrun/util.py
+++ b/drakrun/drakrun/util.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config, dataclass_json
 
-log = logging.getLogger("drakrun")
+log = logging.getLogger(__name__)
 
 hexstring = config(
     encoder=lambda v: hex(v),
@@ -101,12 +101,12 @@ def safe_delete(file_path) -> bool:
     try:
         if os.path.exists(file_path):
             os.remove(file_path)
-            logging.info(f"Deleted {file_path}")
+            log.info(f"Deleted {file_path}")
         else:
-            logging.info(f"Already deleted {file_path}")
+            log.info(f"Already deleted {file_path}")
         return True
     except OSError as e:
-        logging.warning(f"{e.filename}: {e.strerror}")
+        log.warning(f"{e.filename}: {e.strerror}")
         return False
 
 
@@ -149,22 +149,22 @@ def try_run(
     try:
         sub = subprocess.run(list_args, **kwargs)
     except (FileNotFoundError, TypeError) as e:
-        logging.debug("arguments to subprocess")
-        logging.debug(list_args)
-        logging.debug(msg)
-        logging.debug(kwargs)
+        log.debug("arguments to subprocess")
+        log.debug(list_args)
+        log.debug(msg)
+        log.debug(kwargs)
         raise Exception("Command not found") from e
     except subprocess.CalledProcessError as e:
         if e.stdout is not None:
-            logging.debug("stdout: \n{}".format(e.stdout.decode()))
+            log.debug("stdout: \n{}".format(e.stdout.decode()))
         if e.stderr is not None:
-            logging.debug("stderr: \n{}".format(e.stderr.decode()))
-        logging.debug("returncode: {}".format(e.returncode))
+            log.debug("stderr: \n{}".format(e.stderr.decode()))
+        log.debug("returncode: {}".format(e.returncode))
         if reraise:
             raise Exception(msg) from e
         else:
-            logging.warning(msg)
-            logging.debug(traceback.format_exc())
+            log.warning(msg)
+            log.debug(traceback.format_exc())
             return None
     return sub
 

--- a/drakrun/drakrun/vba_graph.py
+++ b/drakrun/drakrun/vba_graph.py
@@ -339,6 +339,8 @@ def get_outer_nodes_from_vba_file(filename):
         dg = vba2graph_gen(input_vba_content)
         return find_outer_nodes(dg)
     except Exception as ex:
-        log.warning("Something went wrong. Perhaps this is not an office document.",
-                    exc_info=True)
+        log.warning(
+            "Something went wrong. Perhaps this is not an office document.",
+            exc_info=True,
+        )
         return None

--- a/drakrun/drakrun/vba_graph.py
+++ b/drakrun/drakrun/vba_graph.py
@@ -17,6 +17,8 @@ fixes and added support for python3.
 
 LINE_SEP = "\n"
 
+log = logging.getLogger(__name__)
+
 
 class Graph:
     """Simple implementation of directed graph to minimalize number of dependencies."""
@@ -33,7 +35,7 @@ class Graph:
 
 
 def vba2graph_from_vba_object(filepath):
-    logging.info("Extracting macros from file")
+    log.info("Extracting macros from file")
     full_vba_code = ""
     vba_parser = VBA_Parser(filepath)
     for (
@@ -201,7 +203,7 @@ def vba_extract_functions(vba_content_lines):
                     (func_start_pos + len("Sub ")) : vba_line.find("(")
                 ]
             else:
-                logging.error("Error parsing function name")
+                log.error("Error parsing function name")
                 sys.exit(1)
 
         elif inside_function:
@@ -260,7 +262,7 @@ def vba_extract_properties(vba_content_lines):
                 )
 
             else:
-                logging.error("Error parsing property name")
+                log.error("Error parsing property name")
                 sys.exit(1)
 
         # Check if we are inside a property code.
@@ -337,6 +339,6 @@ def get_outer_nodes_from_vba_file(filename):
         dg = vba2graph_gen(input_vba_content)
         return find_outer_nodes(dg)
     except Exception as ex:
-        logging.warning("Something went wrong. Perhaps this is not an office document.")
-        logging.warning(ex)
+        log.warning("Something went wrong. Perhaps this is not an office document.",
+                    exc_info=True)
         return None

--- a/drakrun/drakrun/vba_graph.py
+++ b/drakrun/drakrun/vba_graph.py
@@ -338,7 +338,7 @@ def get_outer_nodes_from_vba_file(filename):
         input_vba_content = vba2graph_from_vba_object(filename)
         dg = vba2graph_gen(input_vba_content)
         return find_outer_nodes(dg)
-    except Exception as ex:
+    except Exception:
         log.warning(
             "Something went wrong. Perhaps this is not an office document.",
             exc_info=True,

--- a/drakrun/drakrun/vm.py
+++ b/drakrun/drakrun/vm.py
@@ -9,7 +9,7 @@ from drakrun.config import ETC_DIR, LIB_DIR, VM_CONFIG_DIR, VOLUME_DIR, InstallI
 from drakrun.storage import StorageBackendBase, get_storage_backend
 from drakrun.util import safe_delete, try_run
 
-log = logging.getLogger("drakrun")
+log = logging.getLogger(__name__)
 
 FIRST_CDROM_DRIVE = "hdc"
 SECOND_CDROM_DRIVE = "hdd"
@@ -95,11 +95,11 @@ class VirtualMachine:
         if pause:
             args += ["-p"]
         args += [self._cfg_path]
-        logging.info(f"Creating VM {self.vm_name}")
+        log.info(f"Creating VM {self.vm_name}")
         try_run(args, f"Failed to launch VM {self.vm_name}", **kwargs)
 
     def pause(self, **kwargs):
-        logging.info(f"Pausing VM {self.vm_name}")
+        log.info(f"Pausing VM {self.vm_name}")
         try_run(
             ["xl", "pause", self.vm_name],
             f"Failed to pause VM {self.vm_name}",
@@ -107,7 +107,7 @@ class VirtualMachine:
         )
 
     def unpause(self, **kwargs):
-        logging.info(f"Unpausing VM {self.vm_name}")
+        log.info(f"Unpausing VM {self.vm_name}")
         try_run(
             ["xl", "unpause", self.vm_name],
             f"Failed to unpause VM {self.vm_name}",
@@ -115,7 +115,7 @@ class VirtualMachine:
         )
 
     def save(self, filename, pause=False, cont=False, **kwargs):
-        logging.info(f"Saving VM {self.vm_name}")
+        log.info(f"Saving VM {self.vm_name}")
         args = ["xl", "save"]
 
         # no such args will shutdown the VM after saving
@@ -161,7 +161,7 @@ class VirtualMachine:
             self.backend.rollback_vm_storage(self.vm_id)
 
         args += [self._cfg_path, snapshot_path]
-        logging.info(f"Restoring VM {self.vm_name}")
+        log.info(f"Restoring VM {self.vm_name}")
         try_run(args, msg=f"Failed to restore VM {self.vm_name}", **kwargs)
 
     def destroy(self, **kwargs):
@@ -169,7 +169,7 @@ class VirtualMachine:
         :raises: subprocess.CalledProcessError
         """
         if self.is_running:
-            logging.info(f"Destroying {self.vm_name}")
+            log.info(f"Destroying {self.vm_name}")
             try_run(
                 ["xl", "destroy", self.vm_name],
                 f"Failed to destroy VM {self.vm_name}",


### PR DESCRIPTION
- Reaching root logger via `logging` module-level methods is highly discouraged because:

> This function (as well as [info()](https://docs.python.org/3/library/logging.html#logging.info), [warning()](https://docs.python.org/3/library/logging.html#logging.warning), [error()](https://docs.python.org/3/library/logging.html#logging.error) and [critical()](https://docs.python.org/3/library/logging.html#logging.critical)) will call [basicConfig()](https://docs.python.org/3/library/logging.html#logging.basicConfig) if the root logger doesn’t have any handler attached.

- Library/utils code should never use root loggers and drakrun module hierarchy should be used instead.
- "drakrun.*" logs can be easily redirected to Karton logger by attaching Karton handler to `drakrun` (which was already done)