### PR TITLE
Use 'console_scripts' instead of 'scripts' in drakrun

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -806,15 +806,11 @@ def validate_xen_commandline(ignore_failure: bool) -> None:
             sys.exit(1)
 
 
-def cmdline_main() -> None:
+def main() -> None:
     parser = argparse.ArgumentParser(description="Kartonized drakrun <3")
     parser.add_argument("instance", type=int, help="Instance identifier")
     args = parser.parse_args()
 
-    main(args)
-
-
-def main(args) -> None:
     conf_path = os.path.join(ETC_DIR, "config.ini")
     conf = Config(conf_path)
 
@@ -832,4 +828,4 @@ def main(args) -> None:
 
 
 if __name__ == "__main__":
-    cmdline_main()
+    main()

--- a/drakrun/drakrun/py-scripts/drakpdb
+++ b/drakrun/drakrun/py-scripts/drakpdb
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-from drakrun.drakpdb import main
-
-main()

--- a/drakrun/drakrun/py-scripts/drakplayground
+++ b/drakrun/drakrun/py-scripts/drakplayground
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.playground as playground
-
-playground.main()

--- a/drakrun/drakrun/py-scripts/drakpush
+++ b/drakrun/drakrun/py-scripts/drakpush
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.drakpush as dp
-
-dp.main()
-

--- a/drakrun/drakrun/py-scripts/drakrun
+++ b/drakrun/drakrun/py-scripts/drakrun
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.main as dm
-
-dm.cmdline_main()

--- a/drakrun/drakrun/py-scripts/draksetup
+++ b/drakrun/drakrun/py-scripts/draksetup
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.draksetup as ds
-
-ds.main()

--- a/drakrun/drakrun/py-scripts/draktest
+++ b/drakrun/drakrun/py-scripts/draktest
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.regression as draktestd
-
-draktestd.RegressionTester.submit_main()

--- a/drakrun/drakrun/py-scripts/draktestd
+++ b/drakrun/drakrun/py-scripts/draktestd
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-import drakrun.regression as draktestd
-
-draktestd.RegressionTester.main()

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -24,8 +24,8 @@ setup(
             "drakpush = drakrun.drakpush:main",
             "drakpdb = drakrun.drakpdb:main",
             "drakplayground = drakrun.playground:main",
-            "draktestd = drakrun.regression:RegressionTester.main"
-            "draktest = drakrun.regression:RegressionTester.submit_main"
+            "draktestd = drakrun.regression:RegressionTester.main",
+            "draktest = drakrun.regression:RegressionTester.submit_main",
         ]
     },
     classifiers=[

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -17,15 +17,17 @@ setup(
     packages=["drakrun", "drakrun.lib", "drakrun.test"],
     include_package_data=True,
     install_requires=open("requirements.txt").read().splitlines(),
-    scripts=[
-        "drakrun/py-scripts/drakrun",
-        "drakrun/py-scripts/draksetup",
-        "drakrun/py-scripts/drakpush",
-        "drakrun/py-scripts/drakpdb",
-        "drakrun/py-scripts/drakplayground",
-        "drakrun/py-scripts/draktestd",
-        "drakrun/py-scripts/draktest",
-    ],
+    entry_points={
+        "console_scripts": [
+            "drakrun = drakrun.main:main",
+            "draksetup = drakrun.draksetup:main",
+            "drakpush = drakrun.drakpush:main",
+            "drakpdb = drakrun.drakpdb:main",
+            "drakplayground = drakrun.playground:main",
+            "draktestd = drakrun.regression:RegressionTester.main"
+            "draktest = drakrun.regression:RegressionTester.submit_main"
+        ]
+    },
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",


### PR DESCRIPTION
I guess it was more easy during development to run such script directly from the directory, but the recommended way are console_scripts. With a good package design, we can call a specific tool with `python3 -m` anyway.