### PR TITLE
Reorder the startup procedure

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -196,14 +196,10 @@ class DrakrunKarton(Karton):
         This depends on the content magic, "extension" header and "file_name" payload.
         """
         extension = self._karton_safe_get_headers(task, "extension", "exe").lower()
-
         if "(DLL)" in magic_output:
             extension = "dll"
-        self.log.info("Running file as %s", extension)
 
-        # Prepare sample file name
         file_name = task.payload.get("file_name", "malwar") + f".{extension}"
-        # Alphanumeric, dot, underscore, dash
         if not re.match(r"^[a-zA-Z0-9\._\-]+$", file_name):
             raise RuntimeError("Filename contains invalid characters")
 

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -195,7 +195,8 @@ class DrakrunKarton(Karton):
         """Return a tuple of (filename, extension) for a given task.
         This depends on the content magic, "extension" header and "file_name" payload.
         """
-        extension = self._karton_safe_get_headers(task, "extension", "exe").lower()
+        # headers["extensions"] may exist and be None
+        extension = (task.headers.get("extension") or "exe").lower()
         if "(DLL)" in magic_output:
             extension = "dll"
 


### PR DESCRIPTION
Make it a bit more logical, i.e.:

* move early returns even earlier
* factor some self-contained code into helpers like `filename_for_task`