### PR TITLE
Refactor startup command handling

### DIFF
--- a/drakrun/drakrun/lib/sample_startup.py
+++ b/drakrun/drakrun/lib/sample_startup.py
@@ -10,6 +10,10 @@ log = logging.getLogger(__name__)
 
 
 def get_sample_startup_command(extension: str, content: bytes) -> str:
+    """Gets a startup command suitable for running the files with the provided
+    extension. Sometimes content is also parsed to determine the command.
+    Extension should be provided without dot, so `dll` instead of `.dll`.
+    """
     if extension == "dll":
         return get_dll_startup_command(content)
     if extension in ["exe", "bat"]:

--- a/drakrun/drakrun/lib/sample_startup.py
+++ b/drakrun/drakrun/lib/sample_startup.py
@@ -9,28 +9,23 @@ from drakrun.lib.vba_graph import get_outer_nodes_from_vba_file
 log = logging.getLogger(__name__)
 
 
-def get_sample_startup_command(extension, sample, file_path):
-    start_command = None
-
+def get_sample_startup_command(extension: str, content: bytes) -> str:
     if extension == "dll":
-        start_command = get_dll_startup_command(sample.content)
-    elif extension in ["exe", "bat"]:
-        start_command = "%f"
-    elif extension == "ps1":
-        start_command = "powershell.exe -executionpolicy bypass -File %f"
-    elif is_office_file(extension):
-        start_command = get_office_file_startup_command(extension, file_path)
-    elif extension in ["js", "jse", "vbs", "vbe"]:
-        start_command = "wscript.exe %f"
-    elif extension in ["hta", "html", "htm"]:
-        start_command = "mshta.exe %f"
-    else:
-        log.warning(f"Unknown file extension {extension}.")
-        return None
-    return start_command
+        return get_dll_startup_command(content)
+    if extension in ["exe", "bat"]:
+        return "%f"
+    if extension == "ps1":
+        return "powershell.exe -executionpolicy bypass -File %f"
+    if is_office_file(extension):
+        return get_office_file_startup_command(extension, content)
+    if extension in ["js", "jse", "vbs", "vbe"]:
+        return "wscript.exe %f"
+    if extension in ["hta", "html", "htm"]:
+        return "mshta.exe %f"
+    return "cmd.exe /C start %f"
 
 
-def get_office_file_startup_command(extension, file_path):
+def get_office_file_startup_command(extension: str, content: bytes) -> str:
     start_command = ["cmd.exe", "/C", "start"]
     if is_office_word_file(extension):
         start_command.append("winword.exe")
@@ -39,14 +34,13 @@ def get_office_file_startup_command(extension, file_path):
     elif is_office_powerpoint_file(extension):
         start_command.append("powerpnt.exe")
     else:
-        log.warning(f"Unknown office file extension {extension}.")
-        return None
+        raise RuntimeError(f"Unknown office file extension {extension}.")
     start_command.extend(["/t", "%f"])
 
     if file_type_allows_macros(extension):
-        vbaparser = VBA_Parser(file_path)
+        vbaparser = VBA_Parser(f"malware.{extension}", data=content)
         if vbaparser.detect_vba_macros():
-            outer_macros = get_outer_nodes_from_vba_file(file_path)
+            outer_macros = get_outer_nodes_from_vba_file(vbaparser)
             if not outer_macros:
                 outer_macros = []
             for outer_macro in outer_macros:
@@ -55,7 +49,7 @@ def get_office_file_startup_command(extension, file_path):
     return subprocess.list2cmdline(start_command)
 
 
-def get_dll_startup_command(pe_data):
+def get_dll_startup_command(pe_data: bytes) -> str:
     d = [pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_EXPORT"]]
     pe = pefile.PE(data=pe_data, fast_load=True)
     pe.parse_data_directories(directories=d)
@@ -85,23 +79,23 @@ def get_dll_startup_command(pe_data):
     return "regsvr32 /s %f"
 
 
-def file_type_allows_macros(extension):
+def file_type_allows_macros(extension: str) -> bool:
     return extension in ["docm", "dotm", "xls", "xlsm", "xltm", "pptx"]
 
 
-def is_office_word_file(extension):
+def is_office_word_file(extension: str) -> bool:
     return extension in ["doc", "docm", "docx", "dotm", "rtf"]
 
 
-def is_office_excel_file(extension):
+def is_office_excel_file(extension: str) -> bool:
     return extension in ["xls", "xlsx", "xlsm", "xltx", "xltm"]
 
 
-def is_office_powerpoint_file(extension):
+def is_office_powerpoint_file(extension: str) -> bool:
     return extension in ["ppt", "pptx"]
 
 
-def is_office_file(extension):
+def is_office_file(extension: str) -> bool:
     return (
         is_office_word_file(extension)
         or is_office_excel_file(extension)

--- a/drakrun/drakrun/lib/vba_graph.py
+++ b/drakrun/drakrun/lib/vba_graph.py
@@ -34,10 +34,9 @@ class Graph:
         self.edges.add((src, dst))
 
 
-def vba2graph_from_vba_object(filepath):
+def vba2graph_from_vba_object(vba_parser):
     log.info("Extracting macros from file")
     full_vba_code = ""
-    vba_parser = VBA_Parser(filepath)
     for (
         subfilename,
         stream_path,
@@ -333,9 +332,9 @@ def find_outer_nodes(dg):
     return outer_nodes
 
 
-def get_outer_nodes_from_vba_file(filename):
+def get_outer_nodes_from_vba_file(vba_parser):
     try:
-        input_vba_content = vba2graph_from_vba_object(filename)
+        input_vba_content = vba2graph_from_vba_object(vba_parser)
         dg = vba2graph_gen(input_vba_content)
         return find_outer_nodes(dg)
     except Exception:

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import magic
 from karton.core import Config, Karton, LocalResource, Resource, Task
 
-from drakrun.lib.sample_startup import get_sample_startup_command
 from drakrun.lib.config import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
@@ -41,6 +40,7 @@ from drakrun.lib.networking import (
     start_dnsmasq,
     start_tcpdump_collector,
 )
+from drakrun.lib.sample_startup import get_sample_startup_command
 from drakrun.lib.storage import get_storage_backend
 from drakrun.lib.util import (
     RuntimeInfo,

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -202,13 +202,6 @@ class DrakrunConfig:
         return plugins
 
 
-class Drakrun:
-    """A utility class, independent of Karton (with exception of the config),
-    that can be used to analyse samples and collecting the results"""
-
-    pass
-
-
 class DrakrunKarton(Karton):
     version = DRAKRUN_VERSION
     identity = "karton.drakrun-prod"


### PR DESCRIPTION
TODO for the nexts PR: completely eliminate the concept of the "workdir" and "outdir".

* workdir is unnecessary
* outdir should be a regular target directory (temporary directory for karton), cleaned after analysis