### PR TITLE
Separate 'analyzer' module

### DIFF
--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -128,7 +128,7 @@ def filename_for_task(options: AnalysisOptions) -> Tuple[str, str]:
             extension = "exe"
     # Make sure the extension is lowercase
     extension = extension.lower()
-    file_name = options.sample_filename + f".{extension}"
+    file_name = (options.sample_filename or "malwar") + f".{extension}"
     if not re.match(r"^[a-zA-Z0-9\._\-]+$", file_name):
         raise RuntimeError("Filename contains invalid characters")
 
@@ -422,7 +422,7 @@ def main():
         description="Analyze file in Drakvuf",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("sample-path", help="Path to the sample")
+    parser.add_argument("sample_path", help="Path to the sample")
     parser.add_argument(
         "--vm-id",
         help="Virtual machine ID to use for analysis",
@@ -501,9 +501,9 @@ def main():
 
     args = parser.parse_args()
     analysis_options = AnalysisOptions(
-        sample_path=args.sample_path,
+        sample_path=pathlib.Path(args.sample_path),
         vm_id=args.vm_id,
-        output_dir=args.output_dir,
+        output_dir=pathlib.Path(args.output_dir),
         plugins=args.plugins,
         timeout=args.timeout,
         hooks_path=(

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -418,7 +418,10 @@ class PluginsArgAction(argparse.Action):
 def main():
     logging.basicConfig(level=logging.INFO)
     drakconfig = load_config()
-    parser = argparse.ArgumentParser(description="Analyze file in Drakvuf")
+    parser = argparse.ArgumentParser(
+        description="Analyze file in Drakvuf",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument("sample-path", help="Path to the sample")
     parser.add_argument(
         "--vm-id",

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -396,13 +396,13 @@ def main():
     logging.basicConfig(level=logging.INFO)
     drakconfig = load_config()
     parser = argparse.ArgumentParser(
-        description="Analyze file in Drakvuf",
+        description="Analyze a file in Drakvuf",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("sample_path", help="Path to the sample")
     parser.add_argument(
         "--vm-id",
-        help="Virtual machine ID to use for analysis",
+        help="ID of the Virtual machine to use for analysis",
         type=int,
         required=True,
     )
@@ -413,7 +413,7 @@ def main():
     )
     parser.add_argument(
         "--plugins",
-        help="DRAKVUF plugins to enable during analysis",
+        help="Comma separated DRAKVUF plugins to use",
         default=drakconfig.drakvuf_plugins.get_plugin_list(),
         action=PluginsArgAction,
     )
@@ -421,13 +421,13 @@ def main():
         "--timeout",
         default=drakconfig.drakrun.analysis_timeout,
         type=int,
-        help="Timeout in seconds for analysis",
+        help="Analysis timeout, in seconds",
     )
     parser.add_argument(
         "--hooks-path", help="Path to the custom hook list", required=False
     )
     parser.add_argument(
-        "--start-command", help="Alternative command to start analysis", required=False
+        "--start-command", help="Override the default startup command", required=False
     )
     parser.add_argument(
         "--extension",
@@ -435,7 +435,7 @@ def main():
         required=False,
     )
     parser.add_argument(
-        "--sample-filename", help="Target file name for sample", required=False
+        "--sample-filename", help="Sample filename to use in the VM", required=False
     )
     parser.add_argument(
         "--dns-server",
@@ -457,7 +457,7 @@ def main():
     )
     parser.add_argument(
         "--anti-hammering-threshold",
-        help="Threshold for API hammering detection (detection disabled if 0)",
+        help="Threshold for API hammering detection (or 0 to disable)",
         default=drakconfig.drakrun.anti_hammering_threshold,
         type=int,
     )

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -106,7 +106,6 @@ def filename_for_task(options: AnalysisOptions) -> Tuple[str, str]:
     Return a tuple of (filename, extension) for a given task.
     This depends on the content magic, "extension" and "file_name" options.
     """
-    # TODO: We need to change that, it's too fuzzy
     extension = options.extension
     if not extension:
         magic_output = magic.from_file(options.sample_path)
@@ -149,11 +148,13 @@ def run_tcpdump(vm: DrakvufVM, options: AnalysisOptions):
     )
 
 
-def drop_sample_to_vm(vm: DrakvufVM, sample_path: pathlib.Path) -> str:
+def drop_sample_to_vm(
+    vm: DrakvufVM, sample_path: pathlib.Path, target_filename: str
+) -> str:
     """
     Writes sample to the VM and returns expanded target path
     """
-    target_path = f"%USERPROFILE%\\Desktop\\{sample_path.name}"
+    target_path = f"%USERPROFILE%\\Desktop\\{target_filename}"
     result = vm.injector.write_file(str(sample_path), target_path)
     try:
         return json.loads(result.stdout)["ProcessName"]
@@ -336,7 +337,7 @@ def analyze_sample(options: AnalysisOptions):
     time_started = time.time()
     with run_vm(vm, options) as vm:
         log.info("Copying sample to VM...")
-        target_path = drop_sample_to_vm(vm, options.sample_path)
+        target_path = drop_sample_to_vm(vm, options.sample_path, file_name)
 
         if user_start_command:
             start_command = user_start_command.replace("%f", target_path)

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -403,7 +403,7 @@ def analyze_sample(options: AnalysisOptions):
     compress_ipt(str(ipt_path), str(ipt_zip_path))
 
 
-class PluginsArgActiom(argparse.Action):
+class PluginsArgAction(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if nargs is not None:
             raise ValueError("nargs not allowed")
@@ -416,6 +416,7 @@ class PluginsArgActiom(argparse.Action):
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     drakconfig = load_config()
     parser = argparse.ArgumentParser(description="Analyze file in Drakvuf")
     parser.add_argument("sample-path", help="Path to the sample")
@@ -434,7 +435,7 @@ def main():
         "--plugins",
         help="DRAKVUF plugins to enable during analysis",
         default=drakconfig.drakvuf_plugins.get_plugin_list(),
-        action=PluginsArgActiom,
+        action=PluginsArgAction,
     )
     parser.add_argument(
         "--timeout",

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -35,31 +35,6 @@ from .lib.vm import VirtualMachine
 
 log = logging.getLogger(__name__)
 
-DEFAULT_ANALYSIS_TIMEOUT = 10 * 60
-SUPPORTED_PLUGINS = [
-    "apimon",
-    "bsodmon",
-    "clipboardmon",
-    "cpuidmon",
-    "crashmon",
-    "debugmon",
-    "delaymon",
-    "exmon",
-    "filedelete",
-    "filetracer",
-    "librarymon",
-    "memdump",
-    "procdump",
-    "procmon",
-    "regmon",
-    "rpcmon",
-    "ssdtmon",
-    "syscalls",
-    "tlsmon",
-    "windowmon",
-    "wmimon",
-]
-
 
 class DrakvufVM:
     def __init__(self, vm_id: int):
@@ -115,7 +90,11 @@ def filename_for_task(options: AnalysisOptions) -> Tuple[str, str]:
             extension = "exe"
     # Make sure the extension is lowercase
     extension = extension.lower()
+    # TODO: sample_filename should already contain extension or be fixed
+    #       to the proper extension
     file_name = (options.sample_filename or "malwar") + f".{extension}"
+    # TODO: if sample_filename doesn't match regex, it should fallback
+    #       to the default name
     if not re.match(r"^[a-zA-Z0-9\._\-]+$", file_name):
         raise RuntimeError("Filename contains invalid characters")
 
@@ -455,8 +434,6 @@ def main():
         help="Alternative extension indicating sample format",
         required=False,
     )
-    # TODO: Right now this argument is incorrectly interpreted
-    #       See also: filename_for_task
     parser.add_argument(
         "--sample-filename", help="Target file name for sample", required=False
     )

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -388,8 +388,17 @@ class PluginsArgAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         if option_string is None:
-            raise ValueError("Missing --plugins value")
+            raise ValueError("Value is required for --plugins option")
         setattr(namespace, self.dest, option_string.split(","))
+
+
+def confirm(prompt):
+    while True:
+        answer = input(prompt).lower()
+        if answer == "y":
+            return True
+        elif answer == "n":
+            return False
 
 
 def main():
@@ -400,6 +409,12 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("sample_path", help="Path to the sample")
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Don't ask if output directory can be deleted",
+    )
     parser.add_argument(
         "--vm-id",
         help="ID of the Virtual machine to use for analysis",
@@ -482,13 +497,8 @@ def main():
 
     output_dir = pathlib.Path(args.output_dir)
     if output_dir.exists():
-        confirmation = ["Y", "y", ""]
-        if (
-            input("Output directory already exists. Overwrite? (Y/n)")
-            not in confirmation
-        ):
-            return
-        shutil.rmtree(output_dir)
+        if args.force or confirm("Output directory already exists. Overwrite? (y/n)"):
+            shutil.rmtree(output_dir)
     output_dir.mkdir()
 
     hooks_path = (

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -504,11 +504,11 @@ def main():
 
     output_dir = pathlib.Path(args.output_dir)
     if output_dir.exists():
-        if input("Output directory already exists. Overwrite? (Y/n)") not in [
-            "Y",
-            "y",
-            "",
-        ]:
+        confirmation = ["Y", "y", ""]
+        if (
+            input("Output directory already exists. Overwrite? (Y/n)")
+            not in confirmation
+        ):
             return
         shutil.rmtree(output_dir)
     output_dir.mkdir()

--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -1,0 +1,521 @@
+import argparse
+import contextlib
+import dataclasses
+import hashlib
+import itertools
+import json
+import logging
+import ntpath
+import os
+import pathlib
+import re
+import subprocess
+import zipfile
+from stat import S_ISREG, ST_CTIME, ST_MODE, ST_SIZE
+from typing import Any, Dict, List, Optional, Tuple
+
+import magic
+
+from .lib.config import load_config
+from .lib.drakpdb import dll_file_list
+from .lib.injector import Injector
+from .lib.install_info import InstallInfo
+from .lib.networking import (
+    delete_vm_network,
+    setup_vm_network,
+    start_dnsmasq,
+    start_tcpdump_collector,
+)
+from .lib.paths import ETC_DIR, PROFILE_DIR, RUNTIME_FILE
+from .lib.sample_startup import get_sample_entrypoints, get_sample_startup_command
+from .lib.storage import get_storage_backend
+from .lib.util import RuntimeInfo, graceful_exit
+from .lib.vm import VirtualMachine
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ANALYSIS_TIMEOUT = 10 * 60
+SUPPORTED_PLUGINS = [
+    "apimon",
+    "bsodmon",
+    "clipboardmon",
+    "cpuidmon",
+    "crashmon",
+    "debugmon",
+    "delaymon",
+    "exmon",
+    "filedelete",
+    "filetracer",
+    "librarymon",
+    "memdump",
+    "procdump",
+    "procmon",
+    "regmon",
+    "rpcmon",
+    "ssdtmon",
+    "syscalls",
+    "tlsmon",
+    "windowmon",
+    "wmimon",
+]
+
+
+class DrakvufVM:
+    def __init__(self, vm_id: int):
+        self.vm_id = vm_id
+        self.install_info = InstallInfo.load()
+        self.storage_backend = get_storage_backend(self.install_info)
+        self.runtime_info = RuntimeInfo.load(RUNTIME_FILE)
+        self.kernel_profile_path = os.path.join(PROFILE_DIR, "kernel.json")
+        self.vm = VirtualMachine(self.storage_backend, vm_id)
+        self.injector = Injector(
+            self.vm.vm_name, self.runtime_info, self.kernel_profile_path
+        )
+
+
+def prepare_output_dir(output_dir: pathlib.Path):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise RuntimeError("Output directory is not empty")
+    # TODO: Right now I use a bit different structure: in the previous
+    #       code, all things were additionally nested in 'output' dir
+    (output_dir / "dumps").mkdir()
+    (output_dir / "ipt").mkdir()
+
+
+@dataclasses.dataclass
+class AnalysisOptions:
+    sample_path: pathlib.Path
+    vm_id: int
+    output_dir: pathlib.Path
+    plugins: List[str]
+    timeout: int = 600
+    hooks_path: pathlib.Path = pathlib.Path(ETC_DIR) / "hooks.txt"
+    start_command: Optional[str] = None
+    extension: Optional[str] = None
+    sample_filename: Optional[str] = None
+    dns_server: Optional[str] = None
+    out_interface: Optional[str] = None
+    net_enable: bool = True
+    anti_hammering_threshold: int = 0
+    syscall_filter: Optional[str] = None
+    raw_memory_dump: bool = False
+
+
+def get_sample_sha256(sample_path: pathlib.Path) -> str:
+    sha256 = hashlib.sha256()
+    with sample_path.open("rb") as f:
+        while True:
+            block = f.read(65536)
+            if not block:
+                break
+            sha256.update(block)
+    return sha256.hexdigest()
+
+
+def filename_for_task(options: AnalysisOptions) -> Tuple[str, str]:
+    """
+    Return a tuple of (filename, extension) for a given task.
+    This depends on the content magic, "extension" and "file_name" options.
+    """
+    # TODO: We need to change that, it's too fuzzy
+    extension = options.extension
+    if not extension:
+        magic_output = magic.from_file(options.sample_path)
+        if "(DLL)" in magic_output:
+            extension = "dll"
+        else:
+            extension = "exe"
+    # Make sure the extension is lowercase
+    extension = extension.lower()
+    file_name = options.sample_filename + f".{extension}"
+    if not re.match(r"^[a-zA-Z0-9\._\-]+$", file_name):
+        raise RuntimeError("Filename contains invalid characters")
+
+    return file_name, extension
+
+
+@contextlib.contextmanager
+def run_vm(vm: DrakvufVM, options: AnalysisOptions):
+    setup_vm_network(
+        vm.vm_id,
+        options.net_enable,
+        options.out_interface,
+        options.dns_server,
+    )
+    try:
+        with graceful_exit(start_dnsmasq(vm.vm_id, options.dns_server)):
+            vm.vm.restore()
+            try:
+                yield vm
+            finally:
+                vm.vm.destroy()
+    finally:
+        delete_vm_network(vm.vm_id)
+
+
+def run_tcpdump(vm: DrakvufVM, options: AnalysisOptions):
+    # todo: start_tcpdump_collector should accept pathlib.Path
+    return graceful_exit(
+        start_tcpdump_collector(vm.vm.get_domid(), str(options.output_dir))
+    )
+
+
+def drop_sample_to_vm(vm: DrakvufVM, sample_path: pathlib.Path) -> str:
+    """
+    Writes sample to the VM and returns expanded target path
+    """
+    target_path = f"%USERPROFILE%\\Desktop\\{sample_path.name}"
+    result = vm.injector.write_file(str(sample_path), target_path)
+    try:
+        return json.loads(result.stdout)["ProcessName"]
+    except ValueError as e:
+        log.error("JSON decode error occurred when tried to parse injector's logs.")
+        log.error(f"Raw log line: {result.stdout}")
+        raise e
+
+
+def run_post_restore_vm_commands(vm: DrakvufVM, options: AnalysisOptions):
+    log.info("Running post-restore VM commands...")
+    if options.net_enable:
+        max_attempts = 3
+        for i in range(max_attempts):
+            try:
+                log.info(f"Trying to setup network (attempt {i + 1}/{max_attempts})")
+                vm.injector.create_process(
+                    "cmd /C ipconfig /release >nul", wait=True, timeout=120
+                )
+                vm.injector.create_process(
+                    "cmd /C ipconfig /renew >nul", wait=True, timeout=120
+                )
+                break
+            except Exception:
+                log.exception("Analysis attempt failed. Retrying...")
+        else:
+            log.warning(f"Giving up after {max_attempts} failures...")
+            raise RuntimeError("Failed to setup VM network after 3 attempts")
+
+
+def get_profile_args_list() -> List[str]:
+    files = os.listdir(PROFILE_DIR)
+
+    out = []
+
+    for profile in dll_file_list:
+        if profile.arg is None:
+            continue
+        if f"{profile.dest}.json" in files:
+            out.extend([profile.arg, os.path.join(PROFILE_DIR, f"{profile.dest}.json")])
+
+    return out
+
+
+def build_drakvuf_cmdline(
+    vm: DrakvufVM,
+    cwd: str,
+    full_cmd: str,
+    plugins: List[str],
+    options: AnalysisOptions,
+) -> List[str]:
+    plugin_args = list(
+        itertools.chain.from_iterable(["-a", plugin] for plugin in sorted(plugins))
+    )
+    memdumps_dir = options.output_dir / "dumps"
+    ipt_dir = options.output_dir / "ipt"
+    drakvuf_cmd = (
+        ["drakvuf"]
+        + plugin_args
+        + [
+            "-o",
+            "json",
+            # be aware of https://github.com/tklengyel/drakvuf/pull/951
+            "-F",  # enable fast singlestep
+            "-j",
+            "60",
+            "-t",
+            str(options.timeout),
+            "-i",
+            str(vm.runtime_info.inject_pid),
+            "-k",
+            hex(vm.runtime_info.vmi_offsets.kpgd),
+            "-d",
+            vm.vm.vm_name,
+            "--dll-hooks-list",
+            options.hooks_path,
+            "--memdump-dir",
+            str(memdumps_dir),
+            "--ipt-dir",
+            str(ipt_dir),
+            "--ipt-trace-user",
+            "--codemon-dump-dir",
+            str(ipt_dir),
+            "--codemon-log-everything",
+            "--codemon-analyse-system-dll-vad",
+            "-r",
+            str(vm.kernel_profile_path),
+            "-e",
+            full_cmd,
+            "-c",
+            cwd,
+        ]
+    )
+
+    if options.anti_hammering_threshold:
+        drakvuf_cmd.extend(["--traps-ttl", str(options.anti_hammering_threshold)])
+
+    drakvuf_cmd.extend(get_profile_args_list())
+
+    if options.syscall_filter:
+        drakvuf_cmd.extend(["-S", options.syscall_filter])
+
+    return drakvuf_cmd
+
+
+def crop_dumps(dirpath: str, target_zip: str) -> List[Dict[str, Any]]:
+    zipf = zipfile.ZipFile(target_zip, "w", zipfile.ZIP_DEFLATED)
+
+    entries = (os.path.join(dirpath, fn) for fn in os.listdir(dirpath))
+    entries = ((os.stat(path), path) for path in entries)
+
+    entries = (
+        (stat[ST_CTIME], path, stat[ST_SIZE])
+        for stat, path in entries
+        if S_ISREG(stat[ST_MODE])
+    )
+
+    max_total_size = 300 * 1024 * 1024  # 300 MB
+    current_size = 0
+
+    dumps_metadata = []
+    for _, path, size in sorted(entries):
+        current_size += size
+
+        if current_size <= max_total_size:
+            # Store files under dumps/
+            file_basename = os.path.basename(path)
+            if re.fullmatch(r"[a-f0-9]{4,16}_[a-f0-9]{16}", file_basename):
+                # If file is memory dump then append metadata that can be
+                # later attached as payload when creating an `analysis` task.
+                dump_base = hex(int(file_basename.split("_")[0], 16))
+                dumps_metadata.append(
+                    {
+                        "filename": os.path.join("dumps", file_basename),
+                        "base_address": dump_base,
+                    }
+                )
+            zipf.write(path, os.path.join("dumps", file_basename))
+        os.unlink(path)
+
+    # No dumps, force empty directory
+    if current_size == 0:
+        zipf.writestr(zipfile.ZipInfo("dumps/"), "")
+
+    if current_size > max_total_size:
+        log.warning(
+            "Some dumps were deleted, because the configured size threshold was exceeded."
+        )
+    return dumps_metadata
+
+
+def compress_ipt(dirpath: str, target_zip: str) -> None:
+    """
+    Compress the directory specified by dirpath to target_zip file.
+    """
+    zipf = zipfile.ZipFile(target_zip, "w", zipfile.ZIP_DEFLATED)
+
+    for root, dirs, files in os.walk(dirpath):
+        for file in files:
+            zipf.write(
+                os.path.join(root, file),
+                os.path.join("ipt", os.path.relpath(os.path.join(root, file), dirpath)),
+            )
+            os.unlink(os.path.join(root, file))
+
+
+def analyze_sample(options: AnalysisOptions):
+    output_dir = options.output_dir
+    prepare_output_dir(output_dir)
+    vm = DrakvufVM(options.vm_id)
+
+    magic.from_file(options.sample_path)
+    file_name, extension = filename_for_task(options)
+    log.info("Using file name %s", file_name)
+
+    user_start_command = options.start_command
+    # TODO: Read directly from file
+    sample_content = options.sample_path.read_bytes()
+    sample_entrypoints = get_sample_entrypoints(extension, sample_content)
+    with run_vm(vm, options) as vm:
+        log.info("Copying sample to VM...")
+        target_path = drop_sample_to_vm(vm, options.sample_path)
+
+        if user_start_command:
+            start_command = user_start_command.replace("%f", target_path)
+        else:
+            start_command = get_sample_startup_command(
+                target_path, extension, sample_entrypoints
+            )
+        log.info("Using command: %s", start_command)
+
+        run_post_restore_vm_commands(vm, options)
+
+        cwd = ntpath.dirname(target_path)
+        drakvuf_cmd = build_drakvuf_cmdline(
+            vm, cwd, start_command, plugins=options.plugins, options=options
+        )
+
+        drakmon_log_path = output_dir / "drakmon.log"
+        with run_tcpdump(vm, options), drakmon_log_path.open("wb") as drakmon_log:
+            try:
+                subprocess.run(
+                    drakvuf_cmd,
+                    stdout=drakmon_log,
+                    check=True,
+                    timeout=options.timeout + 60,
+                )
+            except subprocess.CalledProcessError as e:
+                # see DRAKVUF src/exitcodes.h for more details
+                INJECTION_UNSUCCESSFUL = 4
+
+                if e.returncode == INJECTION_UNSUCCESSFUL:
+                    log.error("Sample startup failed")
+                else:
+                    # Something bad happened
+                    raise e
+            except subprocess.TimeoutExpired as e:
+                log.error("DRAKVUF timeout expired")
+                raise e
+
+        if options.raw_memory_dump:
+            vm.vm.memory_dump(str(output_dir / "post_sample.raw_memdump.gz"))
+
+    log.info("Analysis done. Collecting artifacts...")
+
+    # Make sure dumps have a reasonable size.
+    # Calculate dumps_metadata as it's required by the `analysis` task format.
+    dumps_path = output_dir / "dumps"
+    dumps_zip_path = output_dir / "dumps.zip"
+    crop_dumps(str(dumps_path), str(dumps_zip_path))
+
+    # Compress IPT traces, they're quite large however they compress well
+    ipt_path = output_dir / "ipt"
+    ipt_zip_path = output_dir / "ipt.zip"
+    compress_ipt(str(ipt_path), str(ipt_zip_path))
+
+
+class PluginsArgActiom(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string is None:
+            raise ValueError("Missing --plugins value")
+        setattr(namespace, self.dest, option_string.split(","))
+
+
+def main():
+    drakconfig = load_config()
+    parser = argparse.ArgumentParser(description="Analyze file in Drakvuf")
+    parser.add_argument("sample-path", help="Path to the sample")
+    parser.add_argument(
+        "--vm-id",
+        help="Virtual machine ID to use for analysis",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Path where analysis results will be written",
+        required=True,
+    )
+    parser.add_argument(
+        "--plugins",
+        help="DRAKVUF plugins to enable during analysis",
+        default=drakconfig.drakvuf_plugins.get_plugin_list(),
+        action=PluginsArgActiom,
+    )
+    parser.add_argument(
+        "--timeout",
+        default=drakconfig.drakrun.analysis_timeout,
+        type=int,
+        help="Timeout in seconds for analysis",
+    )
+    parser.add_argument(
+        "--hooks-path", help="Path to the custom hook list", required=False
+    )
+    parser.add_argument(
+        "--start-command", help="Alternative command to start analysis", required=False
+    )
+    parser.add_argument(
+        "--extension",
+        help="Alternative extension indicating sample format",
+        required=False,
+    )
+    # TODO: Right now this argument is incorrectly interpreted
+    #       See also: filename_for_task
+    parser.add_argument(
+        "--sample-filename", help="Target file name for sample", required=False
+    )
+    parser.add_argument(
+        "--dns-server",
+        help="DNS server to use for analysis",
+        default=drakconfig.drakrun.dns_server,
+        required=False,
+    )
+    parser.add_argument(
+        "--out-interface",
+        help="Interface to be used by VM for Internet communication",
+        default=drakconfig.drakrun.out_interface,
+        required=False,
+    )
+    parser.add_argument(
+        "--net-enable",
+        help="If enabled, VM will be able to connect to the Internet via out-interface",
+        default=drakconfig.drakrun.net_enable,
+        action=argparse.BooleanOptionalAction,
+    )
+    parser.add_argument(
+        "--anti-hammering-threshold",
+        help="Threshold for API hammering detection (detection disabled if 0)",
+        default=drakconfig.drakrun.anti_hammering_threshold,
+        type=int,
+    )
+    parser.add_argument(
+        "--syscall-filter",
+        help="Syscall filter for syscalls plugin",
+        default=drakconfig.drakrun.syscall_filter,
+        type=str,
+    )
+    parser.add_argument(
+        "--raw-memory-dump",
+        help="Make full memory dump of VM after analysis",
+        default=drakconfig.drakrun.raw_memory_dump,
+        action=argparse.BooleanOptionalAction,
+    )
+
+    args = parser.parse_args()
+    analysis_options = AnalysisOptions(
+        sample_path=args.sample_path,
+        vm_id=args.vm_id,
+        output_dir=args.output_dir,
+        plugins=args.plugins,
+        timeout=args.timeout,
+        hooks_path=(
+            pathlib.Path(args.hooks_path)
+            if args.hooks_path
+            else AnalysisOptions.hooks_path
+        ),
+        start_command=args.start_command,
+        extension=args.extension,
+        sample_filename=args.sample_filename,
+        dns_server=args.dns_server,
+        out_interface=args.out_interface,
+        net_enable=args.net_enable,
+        anti_hammering_threshold=args.anti_hammering_threshold,
+        syscall_filter=args.syscall_filter,
+        raw_memory_dump=args.raw_memory_dump,
+    )
+    analyze_sample(analysis_options)
+    # TODO: metadata.json

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -339,7 +339,6 @@ class DrakrunKarton(Karton):
             sample,
             str(output_dir),
             metadata,
-            analysis_metadata["dumps_metadata"],
             quality,
         )
 

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -1,40 +1,28 @@
 #!/usr/bin/python3
 
 import argparse
-import contextlib
 import functools
 import hashlib
 import json
 import logging
-import ntpath
 import os
-import re
+import pathlib
 import shutil
 import socket
-import subprocess
 import sys
 import tempfile
-import time
-import zipfile
 from io import StringIO
-from itertools import chain
 from pathlib import Path
-from stat import S_ISREG, ST_CTIME, ST_MODE, ST_SIZE
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, Optional, Union, cast
 
 import magic
-from karton.core import Config, Karton, LocalResource, Resource, Task
+from karton.core import Config, Karton, LocalResource, RemoteResource, Resource, Task
 
+from drakrun.analyzer import AnalysisOptions, analyze_sample
 from drakrun.lib.bindings.xen import get_xen_info, parse_xen_commandline
 from drakrun.lib.config import load_config
 from drakrun.lib.drakpdb import dll_file_list
-from drakrun.lib.injector import Injector
 from drakrun.lib.install_info import InstallInfo
-from drakrun.lib.networking import (
-    setup_vm_network,
-    start_dnsmasq,
-    start_tcpdump_collector,
-)
 from drakrun.lib.paths import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
@@ -42,13 +30,8 @@ from drakrun.lib.paths import (
     RUNTIME_FILE,
     VOLUME_DIR,
 )
-from drakrun.lib.sample_startup import (
-    get_sample_entrypoints,
-    get_sample_startup_command,
-)
-from drakrun.lib.storage import get_storage_backend
-from drakrun.lib.util import RuntimeInfo, file_sha256, graceful_exit
-from drakrun.lib.vm import VirtualMachine, generate_vm_conf
+from drakrun.lib.util import RuntimeInfo, file_sha256
+from drakrun.lib.vm import generate_vm_conf
 from drakrun.version import __version__ as DRAKRUN_VERSION
 
 MAX_TASK_TIMEOUT = 60 * 20  # Never run samples for longer than this
@@ -116,6 +99,17 @@ def with_logs(object_name):
     return decorator
 
 
+def get_sample_sha256(sample_path: pathlib.Path) -> str:
+    sha256 = hashlib.sha256()
+    with sample_path.open("rb") as f:
+        while True:
+            block = f.read(65536)
+            if not block:
+                break
+            sha256.update(block)
+    return sha256.hexdigest()
+
+
 class DrakrunKarton(Karton):
     version = DRAKRUN_VERSION
     identity = "karton.drakrun-prod"
@@ -127,13 +121,6 @@ class DrakrunKarton(Karton):
     def __init__(self, config: Config, instance_id: int) -> None:
         super().__init__(config)
         self.drakconfig = load_config()
-
-        # Now that karton is set up we can plug in our logger
-        moduleLogger = logging.getLogger()
-        for handler in self.log.handlers:
-            moduleLogger.addHandler(handler)
-        moduleLogger.setLevel(logging.INFO)
-
         self.instance_id = instance_id
         self.install_info = InstallInfo.load()
         self.runtime_info = RuntimeInfo.load(RUNTIME_FILE)
@@ -143,15 +130,24 @@ class DrakrunKarton(Karton):
         if not self.backend.minio.bucket_exists("drakrun"):
             self.backend.minio.make_bucket(bucket_name="drakrun")
 
-        setup_vm_network(
-            self.instance_id,
-            self.drakconfig.drakrun.net_enable,
-            self.drakconfig.drakrun.out_interface,
-            self.drakconfig.drakrun.dns_server,
-        )
-
         self.log.info("Calculating snapshot hash...")
         self.snapshot_sha256 = file_sha256(os.path.join(VOLUME_DIR, "snapshot.sav"))
+        self.analysis_dir = pathlib.Path(f"/tmp/drakrun/vm-{self.instance_id}")
+
+    def setup_logger(self, level: Optional[Union[str, int]] = None) -> None:
+        """
+        Called by KartonBase.__init__. In case of drakrun we want to handle logging
+        on root logger level to catch logs from other modules and utilities.
+        We also need to turn on propagation from self.log that is turned off by Karton
+        """
+        # Let Karton make a proper setup
+        super().setup_logger(level)
+        # Then move handlers from Karton logger to root logger
+        root_logger = logging.getLogger()
+        for handler in self.log.handlers:
+            root_logger.addHandler(handler)
+        self.log.handlers.clear()
+        self.log.propagate = True
 
     def timeout_for_task(self, task: Task) -> int:
         """Return a timeout for task - a default for quality or specified by task."""
@@ -164,87 +160,6 @@ class DrakrunKarton(Karton):
             default_timeout = self.drakconfig.drakrun.analysis_timeout
         return task.payload.get("timeout", default_timeout)
 
-    def filename_for_task(self, task: Task, magic_output: str) -> Tuple[str, str]:
-        """Return a tuple of (filename, extension) for a given task.
-        This depends on the content magic, "extension" header and "file_name" payload.
-        """
-        # headers["extensions"] may exist and be None
-        extension = task.headers.get("extension")
-        if not extension:
-            if "(DLL)" in magic_output:
-                extension = "dll"
-            else:
-                extension = "exe"
-        # Make sure the extension is lowercase
-        extension = extension.lower()
-        file_name = task.payload.get("file_name", "malwar") + f".{extension}"
-        if not re.match(r"^[a-zA-Z0-9\._\-]+$", file_name):
-            raise RuntimeError("Filename contains invalid characters")
-
-        return file_name, extension
-
-    def generate_plugin_cmdline(self, plugin_list: List[str]) -> List[str]:
-        return list(
-            chain.from_iterable(["-a", plugin] for plugin in sorted(plugin_list))
-        )
-
-    @property
-    def vm_name(self) -> str:
-        return f"vm-{self.instance_id}"
-
-    def crop_dumps(self, dirpath: str, target_zip: str) -> List[Dict[str, Any]]:
-        zipf = zipfile.ZipFile(target_zip, "w", zipfile.ZIP_DEFLATED)
-
-        entries = (os.path.join(dirpath, fn) for fn in os.listdir(dirpath))
-        entries = ((os.stat(path), path) for path in entries)
-
-        entries = (
-            (stat[ST_CTIME], path, stat[ST_SIZE])
-            for stat, path in entries
-            if S_ISREG(stat[ST_MODE])
-        )
-
-        max_total_size = 300 * 1024 * 1024  # 300 MB
-        current_size = 0
-
-        dumps_metadata = []
-        for _, path, size in sorted(entries):
-            current_size += size
-
-            if current_size <= max_total_size:
-                # Store files under dumps/
-                file_basename = os.path.basename(path)
-                if re.fullmatch(r"[a-f0-9]{4,16}_[a-f0-9]{16}", file_basename):
-                    # If file is memory dump then append metadata that can be
-                    # later attached as payload when creating an `analysis` task.
-                    dump_base = self._get_base_from_drakrun_dump(file_basename)
-                    dumps_metadata.append(
-                        {
-                            "filename": os.path.join("dumps", file_basename),
-                            "base_address": dump_base,
-                        }
-                    )
-                zipf.write(path, os.path.join("dumps", file_basename))
-            os.unlink(path)
-
-        # No dumps, force empty directory
-        if current_size == 0:
-            zipf.writestr(zipfile.ZipInfo("dumps/"), "")
-
-        if current_size > max_total_size:
-            self.log.warning(
-                "Some dumps were deleted, because the configured size threshold was exceeded."
-            )
-        return dumps_metadata
-
-    def _get_base_from_drakrun_dump(self, dump_name: str) -> str:
-        """
-        Drakrun dumps come in form: <base>_<hash> e.g. 405000_688f58c58d798ecb,
-        that can be read as a dump from address 0x405000 with a content hash
-        equal to 688f58c58d798ecb.
-        """
-        return hex(int(dump_name.split("_")[0], 16))
-
     def update_vnc_info(self) -> None:
         """
         Put analysis ID -> drakrun node mapping into Redis.
@@ -253,22 +168,6 @@ class DrakrunKarton(Karton):
         self.backend.redis.set(
             f"drakvnc:{self.analysis_uid}", self.instance_id, ex=3600  # 1h
         )
-
-    def compress_ipt(self, dirpath: str, target_zip: str) -> None:
-        """
-        Compress the directory specified by dirpath to target_zip file.
-        """
-        zipf = zipfile.ZipFile(target_zip, "w", zipfile.ZIP_DEFLATED)
-
-        for root, dirs, files in os.walk(dirpath):
-            for file in files:
-                zipf.write(
-                    os.path.join(root, file),
-                    os.path.join(
-                        "ipt", os.path.relpath(os.path.join(root, file), dirpath)
-                    ),
-                )
-                os.unlink(os.path.join(root, file))
 
     def upload_artifacts(self, analysis_uid: str, outdir: str, subdir: str = ""):
         for fn in os.listdir(os.path.join(outdir, subdir)):
@@ -338,44 +237,6 @@ class DrakrunKarton(Karton):
 
         self.send_task(task)
 
-    @staticmethod
-    def get_profile_list() -> List[str]:
-        files = os.listdir(PROFILE_DIR)
-
-        out = []
-
-        for profile in dll_file_list:
-            if profile.arg is None:
-                continue
-            if f"{profile.dest}.json" in files:
-                out.extend(
-                    [profile.arg, os.path.join(PROFILE_DIR, f"{profile.dest}.json")]
-                )
-
-        return out
-
-    @contextlib.contextmanager
-    def run_vm(self):
-        backend = get_storage_backend(self.install_info)
-        vm = VirtualMachine(backend, self.instance_id)
-
-        try:
-            vm.restore()
-        except subprocess.CalledProcessError:
-            self.log.exception(f"Failed to restore VM {self.vm_name}")
-            with open(f"/var/log/xen/qemu-dm-{self.vm_name}.log", "rb") as f:
-                self.log.error(f.read())
-
-        self.log.info("VM restored")
-
-        try:
-            yield vm
-        finally:
-            try:
-                vm.destroy()
-            except Exception:
-                self.log.exception("Failed to destroy VM")
-
     @property
     def analysis_uid(self) -> str:
         override_uid = self.current_task.payload.get("override_uid")
@@ -388,206 +249,13 @@ class DrakrunKarton(Karton):
 
         return self.current_task.uid
 
-    def _prepare_workdir(self) -> Tuple[str, str]:
-        workdir = os.path.join("/tmp/drakrun", self.vm_name)
-
-        try:
-            if os.path.isdir(workdir):
-                shutil.rmtree(workdir)
-        except OSError:
-            self.log.exception("Failed to clean work directory")
-
-        os.makedirs(workdir, exist_ok=True)
-
-        outdir = os.path.join(workdir, "output")
-        os.mkdir(outdir)
-        os.mkdir(os.path.join(outdir, "dumps"))
-        os.mkdir(os.path.join(outdir, "ipt"))
-
-        return (workdir, outdir)
-
-    def build_drakvuf_cmdline(
-        self,
-        timeout: int,
-        cwd: str,
-        full_cmd: str,
-        dump_dir: str,
-        ipt_dir: str,
-        hooks_path: str,
-        enabled_plugins,
-    ) -> List[str]:
-        kernel_profile = os.path.join(PROFILE_DIR, "kernel.json")
-
-        drakvuf_cmd = (
-            ["drakvuf"]
-            + self.generate_plugin_cmdline(enabled_plugins)
-            + [
-                "-o",
-                "json",
-                # be aware of https://github.com/tklengyel/drakvuf/pull/951
-                "-F",  # enable fast singlestep
-                "-j",
-                "60",
-                "-t",
-                str(timeout),
-                "-i",
-                str(self.runtime_info.inject_pid),
-                "-k",
-                hex(self.runtime_info.vmi_offsets.kpgd),
-                "-d",
-                self.vm_name,
-                "--dll-hooks-list",
-                hooks_path,
-                "--memdump-dir",
-                dump_dir,
-                "--ipt-dir",
-                ipt_dir,
-                "--ipt-trace-user",
-                "--codemon-dump-dir",
-                ipt_dir,
-                "--codemon-log-everything",
-                "--codemon-analyse-system-dll-vad",
-                "-r",
-                kernel_profile,
-                "-e",
-                full_cmd,
-                "-c",
-                cwd,
-            ]
-        )
-
-        if self.drakconfig.drakrun.anti_hammering_threshold:
-            drakvuf_cmd.extend(
-                ["--traps-ttl", str(self.drakconfig.drakrun.anti_hammering_threshold)]
-            )
-
-        drakvuf_cmd.extend(self.get_profile_list())
-
-        if self.drakconfig.drakrun.syscall_filter:
-            drakvuf_cmd.extend(["-S", self.drakconfig.drakrun.syscall_filter])
-
-        return drakvuf_cmd
-
-    def log_startup_failure(self, log_path: str) -> None:
-        self.log.warning("Injection succeeded but the sample didn't execute properly")
-
-        with open(log_path, "r") as drakvuf_log:
-            # There should be only line line
-            for line in drakvuf_log:
-                entry = json.loads(line)
-                if entry["Plugin"] == "inject":
-                    self.log.info("Injection failed with error: %s", entry["Error"])
-                    break
-
-    def analyze_sample(
-        self,
-        sample_path: str,
-        sample_extension: str,
-        sample_entrypoints: List[str],
-        hooks_path: str,
-        outdir: str,
-        user_start_command: Optional[str],
-        timeout: int,
-    ) -> Dict[str, Any]:
-        analysis_info = dict()
-        drakmon_log_fp = os.path.join(outdir, "drakmon.log")
-
-        with self.run_vm() as vm, graceful_exit(
-            start_dnsmasq(self.instance_id, self.drakconfig.drakrun.dns_server)
-        ), graceful_exit(start_tcpdump_collector(vm.get_domid(), outdir)), open(
-            drakmon_log_fp, "wb"
-        ) as drakmon_log:
-            analysis_info["snapshot_version"] = vm.backend.get_vm0_snapshot_time()
-
-            kernel_profile = os.path.join(PROFILE_DIR, "kernel.json")
-
-            self.log.info("Copying sample to VM...")
-            injector = Injector(self.vm_name, self.runtime_info, kernel_profile)
-            result = injector.write_file(
-                sample_path, f"%USERPROFILE%\\Desktop\\{os.path.basename(sample_path)}"
-            )
-
-            try:
-                injected_fn = json.loads(result.stdout)["ProcessName"]
-            except ValueError as e:
-                self.log.error(
-                    "JSON decode error occurred when tried to parse injector's logs."
-                )
-                self.log.error(f"Raw log line: {result.stdout}")
-                raise e
-
-            if user_start_command:
-                start_command = user_start_command.replace("%f", injected_fn)
-            else:
-                start_command = get_sample_startup_command(
-                    injected_fn, sample_extension, sample_entrypoints
-                )
-            analysis_info["start_command"] = start_command
-            self.log.info("Using command: %s", start_command)
-
-            if self.drakconfig.drakrun.net_enable:
-                max_attempts = 3
-                for i in range(max_attempts):
-                    try:
-                        self.log.info(
-                            f"Trying to setup network (attempt {i + 1}/{max_attempts})"
-                        )
-                        injector.create_process(
-                            "cmd /C ipconfig /release >nul", wait=True, timeout=120
-                        )
-                        injector.create_process(
-                            "cmd /C ipconfig /renew >nul", wait=True, timeout=120
-                        )
-                        break
-                    except Exception:
-                        self.log.exception("Analysis attempt failed. Retrying...")
-                else:
-                    self.log.warning(f"Giving up after {max_attempts} failures...")
-                    raise RuntimeError("Failed to setup VM network after 3 attempts")
-
-            # You can request a subset of supported plugins in task payload
-            task_quality = self.current_task.headers.get("quality", "high")
-            supported_plugins = self.drakconfig.drakvuf_plugins.get_plugin_list(
-                task_quality
-            )
-            requested_plugins = self.current_task.payload.get(
-                "plugins", self.drakconfig.drakvuf_plugins.get_plugin_list(task_quality)
-            )
-            analysis_info["plugins"] = list(
-                set(supported_plugins) & set(requested_plugins)
-            )
-
-            drakvuf_cmd = self.build_drakvuf_cmdline(
-                timeout=timeout,
-                cwd=ntpath.dirname(injected_fn),
-                full_cmd=start_command,
-                dump_dir=os.path.join(outdir, "dumps"),
-                ipt_dir=os.path.join(outdir, "ipt"),
-                hooks_path=hooks_path,
-                enabled_plugins=analysis_info["plugins"],
-            )
-
-            try:
-                subprocess.run(
-                    drakvuf_cmd, stdout=drakmon_log, check=True, timeout=timeout + 60
-                )
-            except subprocess.CalledProcessError as e:
-                # see DRAKVUF src/exitcodes.h for more details
-                INJECTION_UNSUCCESSFUL = 4
-
-                if e.returncode == INJECTION_UNSUCCESSFUL:
-                    self.log_startup_failure(drakmon_log_fp)
-                else:
-                    # Something bad happened
-                    raise e
-            except subprocess.TimeoutExpired as e:
-                self.log.exception("DRAKVUF timeout expired")
-                raise e
-
-            if self.drakconfig.drakrun.raw_memory_dump:
-                vm.memory_dump(os.path.join(outdir, "post_sample.raw_memdump.gz"))
-
-        return analysis_info
+    def _prepare_analysis_directory(self) -> pathlib.Path:
+        if self.analysis_dir.exists():
+            shutil.rmtree(self.analysis_dir)
+        self.analysis_dir.mkdir(parents=True)
+        output_dir = self.analysis_dir / "output"
+        output_dir.mkdir()
+        return output_dir
 
     @with_logs("drakrun.log")
     def process(self, task: Task) -> None:
@@ -604,38 +272,40 @@ class DrakrunKarton(Karton):
             )
             return
 
-        sample = task.get_resource("sample")
-        sha256sum = hashlib.sha256(sample.content).hexdigest()
+        sample: RemoteResource = cast(RemoteResource, task.get_resource("sample"))
+        output_dir = self._prepare_analysis_directory()
+
+        sample_path = self.analysis_dir / "sample"
+        sample.download_to_file(str(sample_path))
+        sha256sum = get_sample_sha256(sample_path)
+
         self.log.info(f"Running on: {socket.gethostname()}")
         self.log.info(f"Sample SHA256: {sha256sum}")
         self.log.info(f"Analysis UID: {self.analysis_uid}")
         self.log.info(f"Snapshot SHA256: {self.snapshot_sha256}")
 
-        magic_output = magic.from_buffer(sample.content)
-        file_name, extension = self.filename_for_task(task, magic_output)
-        self.log.info("Using file name %s", file_name)
+        magic_output = magic.from_file(sample_path)
+
+        # TODO: unify this default path somewhere
+        hooks_path = pathlib.Path(ETC_DIR) / "hooks.txt"
+        # If task contains 'custom_hooks' override local defaults
+        if task.has_payload("custom_hooks"):
+            hooks_path = self.analysis_dir / "hooks.txt"
+            custom_hooks = cast(RemoteResource, task.get_resource("custom_hooks"))
+            custom_hooks.download_to_file(str(hooks_path))
 
         user_start_command = task.payload.get("start_command")
-        sample_entrypoints = get_sample_entrypoints(extension, sample.content)
+        extension = task.headers.get("extension")
 
-        # workdir - configs, sample, etc.
-        # outdir - analysis artifacts
-        workdir, outdir = self._prepare_workdir()
-
-        sample_path = os.path.join(workdir, file_name)
-        sample.download_to_file(sample_path)
-
-        # If task contains 'custom_hooks' override local defaults
-        hooks_path = os.path.join(workdir, "hooks.txt")
-        with open(hooks_path, "wb") as hooks:
-            if task.has_payload("custom_hooks"):
-                custom_hooks = task.get_resource("custom_hooks")
-                assert custom_hooks.content is not None
-                hooks.write(custom_hooks.content)
-            else:
-                with open(os.path.join(ETC_DIR, "hooks.txt"), "rb") as default_hooks:
-                    hooks.write(default_hooks.read())
-
+        # You can request a subset of supported plugins in task payload
+        task_quality = self.current_task.headers.get("quality", "high")
+        supported_plugins = self.drakconfig.drakvuf_plugins.get_plugin_list(
+            task_quality
+        )
+        requested_plugins = self.current_task.payload.get(
+            "plugins", self.drakconfig.drakvuf_plugins.get_plugin_list(task_quality)
+        )
+        plugins = list(set(supported_plugins) & set(requested_plugins))
         self.update_vnc_info()
 
         metadata = {
@@ -643,50 +313,38 @@ class DrakrunKarton(Karton):
             "sample_sha256": sha256sum,
             "snapshot_sha256": self.snapshot_sha256,
             "magic_output": magic_output,
-            "time_started": int(time.time()),
         }
 
-        max_attempts = 3
-        for i in range(max_attempts):
-            try:
-                self.log.info(
-                    f"Trying to analyze sample (attempt {i + 1}/{max_attempts})"
-                )
-                info = self.analyze_sample(
-                    sample_path,
-                    extension,
-                    sample_entrypoints,
-                    hooks_path,
-                    outdir,
-                    user_start_command,
-                    timeout,
-                )
-                metadata.update(info)
-                break
-            except Exception:
-                self.log.exception("Analysis attempt failed. Retrying...")
-        else:
-            self.log.warning(f"Giving up after {max_attempts} failures...")
-            return
-
-        self.log.info("Analysis done. Collecting artifacts...")
-
-        # Make sure dumps have a reasonable size.
-        # Calculate dumps_metadata as it's required by the `analysis` task format.
-        dumps_metadata = self.crop_dumps(
-            os.path.join(outdir, "dumps"), os.path.join(outdir, "dumps.zip")
+        analysis_options = AnalysisOptions(
+            sample_path=sample_path,
+            vm_id=self.instance_id,
+            output_dir=output_dir,
+            plugins=plugins,
+            timeout=timeout,
+            hooks_path=hooks_path,
+            start_command=user_start_command,
+            extension=extension,
+            sample_filename=sample.name,
+            dns_server=self.drakconfig.drakrun.dns_server,
+            out_interface=self.drakconfig.drakrun.out_interface,
+            net_enable=self.drakconfig.drakrun.net_enable,
+            anti_hammering_threshold=self.drakconfig.drakrun.anti_hammering_threshold,
+            syscall_filter=self.drakconfig.drakrun.syscall_filter,
+            raw_memory_dump=self.drakconfig.drakrun.raw_memory_dump,
         )
+        analysis_metadata = analyze_sample(analysis_options)
 
-        # Compress IPT traces, they're quite large however they compress well
-        self.compress_ipt(os.path.join(outdir, "ipt"), os.path.join(outdir, "ipt.zip"))
-
-        metadata["time_finished"] = int(time.time())
-
-        with open(os.path.join(outdir, "metadata.json"), "w") as f:
-            f.write(json.dumps(metadata))
+        metadata = {**metadata, **analysis_metadata}
+        (output_dir / "metadata.json").write_text(json.dumps(metadata))
 
         quality = task.headers.get("quality", "high")
-        self.send_raw_analysis(sample, outdir, metadata, dumps_metadata, quality)
+        self.send_raw_analysis(
+            sample,
+            str(output_dir),
+            metadata,
+            analysis_metadata["dumps_metadata"],
+            quality,
+        )
 
 
 def validate_xen_commandline(ignore_failure: bool) -> None:

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -23,6 +23,7 @@ setup(
     entry_points={
         "console_scripts": [
             "drakrun = drakrun.main:main",
+            "drakstart = drakrun.analyzer:main",
             "draksetup = drakrun.draksetup:main",
             "drakpush = drakrun.drakpush:main",
             "drakpdb = drakrun.drakpdb:main",


### PR DESCRIPTION
To make things less hardcoded in the Karton service itself, let's move analysis process to the separate module called "analyzer"

Analyzer is parametrized by `AnalysisOptions` object that is composed from configuration file values and task parameters. `analyzer.analyze_sample` and `AnalysisOptions` interface is used both by DrakrunKarton and new CLI tool called `drakstart` that allows to run raw analysis process directly from CLI. It will be useful tool for setup and further development and debugging.

List of things implemented a bit different than in the original code:
- Sample is downloaded to `/tmp/drakrun/vm-<N>/sample` instead of `/tmp/drakrun/vm-<N>/<target_name>`. The target file name (which is usually `malwar.exe`) is used only when writing file to the target VM.
- `metadata.json` includes `dumps_metadata`
- Network setup is done always at the beginning of the analysis instead of at the start of Karton. Network is also wiped at the end of the analysis, see `analyzer.run_vm`. It sounds a bit cleaner to me as user may change `out_interface`/`dns_server`/`net_enable` settings and we need to setup network accordingly.
- Analysis is not retried only when "retryable" error occurs
- Logging setup is changed, I do it in setup_logger and bind handlers to the root logger. It should fix the "double logging" problem.