### PR TITLE
Handle drakrun config in dedicated object (DrakrunConfig)

### DIFF
--- a/drakrun/drakrun/drakpush.py
+++ b/drakrun/drakrun/drakpush.py
@@ -3,7 +3,7 @@ import os
 
 from karton.core import Config, Producer, Resource, Task
 
-from drakrun.lib.config import ETC_DIR
+from drakrun.lib.paths import ETC_DIR
 
 
 def main():

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -23,17 +23,7 @@ from drakrun.lib.apiscout import (
     build_static_apiscout_profile,
     make_static_apiscout_profile_for_dll,
 )
-from drakrun.lib.config import load_config, DrakrunConfig
-from drakrun.lib.install_info import InstallInfo
-from drakrun.lib.paths import (
-    APISCOUT_PROFILE_DIR,
-    ETC_DIR,
-    LIB_DIR,
-    PROFILE_DIR,
-    RUNTIME_FILE,
-    VM_CONFIG_DIR,
-    VOLUME_DIR,
-)
+from drakrun.lib.config import DrakrunConfig, load_config
 from drakrun.lib.drakpdb import (
     DLL,
     dll_file_list,
@@ -44,6 +34,7 @@ from drakrun.lib.drakpdb import (
     unrequired_dll_file_list,
 )
 from drakrun.lib.injector import Injector
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.networking import (
     delete_all_vm_networks,
     delete_legacy_iptables,
@@ -52,6 +43,15 @@ from drakrun.lib.networking import (
     setup_vm_network,
     start_dnsmasq,
     stop_dnsmasq,
+)
+from drakrun.lib.paths import (
+    APISCOUT_PROFILE_DIR,
+    ETC_DIR,
+    LIB_DIR,
+    PROFILE_DIR,
+    RUNTIME_FILE,
+    VM_CONFIG_DIR,
+    VOLUME_DIR,
 )
 from drakrun.lib.storage import (
     REGISTERED_BACKEND_NAMES,

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -1286,9 +1286,11 @@ def init(envfile: str):
     # Simple activities handled by deb packages before
     # In the future, consider splitting this to remove hard dependency on systemd etc
     drakrun_dir = Path(ETC_DIR)
+    scripts_dir = drakrun_dir / "scripts"
     data_dir = Path(__file__).parent / "data"
 
     drakrun_dir.mkdir(exist_ok=True)
+    scripts_dir.mkdir(exist_ok=True)
     config = (data_dir / "config.ini").read_text()
 
     # This feature is provided for compatibility with minio.env files, but we plan to
@@ -1307,7 +1309,7 @@ def init(envfile: str):
     Path("/etc/systemd/system/drakrun@.service").write_text(systemd_unit)
 
     config_template = (data_dir / "cfg.template").read_text()
-    (drakrun_dir / "scripts" / "cfg.template").write_text(config_template)
+    (scripts_dir / "cfg.template").write_text(config_template)
 
 
 @click.group()

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -39,7 +39,6 @@ from drakrun.lib.networking import (
     delete_all_vm_networks,
     delete_legacy_iptables,
     delete_vm_network,
-    find_default_interface,
     setup_vm_network,
     start_dnsmasq,
     stop_dnsmasq,

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -24,7 +24,8 @@ from drakrun.lib.apiscout import (
     build_static_apiscout_profile,
     make_static_apiscout_profile_for_dll,
 )
-from drakrun.lib.config import (
+from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.paths import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
     LIB_DIR,
@@ -32,7 +33,6 @@ from drakrun.lib.config import (
     RUNTIME_FILE,
     VM_CONFIG_DIR,
     VOLUME_DIR,
-    InstallInfo,
 )
 from drakrun.lib.drakpdb import (
     DLL,

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -74,7 +74,8 @@ class DrakvufPluginsConfigSection(BaseModel):
     high: CommaSeparatedStrList
 
     @field_validator("all", mode="after")
-    def validate_plugin_list(self, plugin_list: List[str]) -> List[str]:
+    @classmethod
+    def validate_plugin_list(cls, plugin_list: List[str]) -> List[str]:
         if not plugin_list:
             raise ValueError("_all_ plugin list must not be empty")
         return plugin_list

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -1,20 +1,45 @@
 import configparser
-from typing import Optional, List
+from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, computed_field, field_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+)
 from typing_extensions import Annotated
+
 from .paths import CONFIG_PATH
 
 CommaSeparatedStrList = Annotated[
     List[str],
-    BeforeValidator(lambda v: [el.strip() for el in v.split(",") if el.strip()])
+    BeforeValidator(lambda v: [el.strip() for el in v.split(",") if el.strip()]),
 ]
 
 DEFAULT_PLUGINS = [
-    "apimon", "bsodmon", "clipboardmon", "cpuidmon", "crashmon", "debugmon",
-    "delaymon", "exmon", "filedelete", "filetracer", "librarymon", "memdump",
-    "procdump", "procmon", "regmon", "rpcmon", "ssdtmon", "syscalls", "tlsmon",
-    "windowmon", "wmimon",
+    "apimon",
+    "bsodmon",
+    "clipboardmon",
+    "cpuidmon",
+    "crashmon",
+    "debugmon",
+    "delaymon",
+    "exmon",
+    "filedelete",
+    "filetracer",
+    "librarymon",
+    "memdump",
+    "procdump",
+    "procmon",
+    "regmon",
+    "rpcmon",
+    "ssdtmon",
+    "syscalls",
+    "tlsmon",
+    "windowmon",
+    "wmimon",
 ]
 
 
@@ -32,7 +57,7 @@ class MinioConfigSection(BaseModel):
 
 
 class DrakrunConfigSection(BaseModel):
-    model_config = ConfigDict(extra='ignore')
+    model_config = ConfigDict(extra="ignore")
 
     raw_memory_dump: bool = Field(default=False)
     net_enable: bool = Field(default=False)
@@ -40,13 +65,15 @@ class DrakrunConfigSection(BaseModel):
     dns_server: str = Field(default="8.8.8.8")
     syscall_filter: Optional[str] = Field(default=None)
     enable_ipt: bool = Field(default=False)
-    analysis_timeout: int = Field(default=10*60)
+    analysis_timeout: int = Field(default=10 * 60)
     use_root_uid: bool = Field(default=False)
     anti_hammering_threshold: int = Field(default=0)
     attach_profiles: bool = Field(default=False)
     attach_apiscout_profile: bool = Field(default=False)
 
-    _analysis_low_timeout: Optional[int] = Field(validation_alias="analysis_low_timeout", default=None)
+    _analysis_low_timeout: Optional[int] = Field(
+        validation_alias="analysis_low_timeout", default=None
+    )
 
     @computed_field
     @property
@@ -57,7 +84,9 @@ class DrakrunConfigSection(BaseModel):
 
 
 class DrakvufPluginsConfigSection(BaseModel):
-    all: CommaSeparatedStrList = Field(validation_alias="_all_", default_factory=lambda: list(DEFAULT_PLUGINS))
+    all: CommaSeparatedStrList = Field(
+        validation_alias="_all_", default_factory=lambda: list(DEFAULT_PLUGINS)
+    )
     low: CommaSeparatedStrList
     normal: CommaSeparatedStrList
 
@@ -82,7 +111,7 @@ class DrakvufPluginsConfigSection(BaseModel):
 
 
 class DrakrunConfig(BaseModel):
-    model_config = ConfigDict(extra='ignore')
+    model_config = ConfigDict(extra="ignore")
 
     redis: RedisConfigSection
     minio: MinioConfigSection
@@ -93,7 +122,9 @@ class DrakrunConfig(BaseModel):
     def load_from_file(filename: str) -> "DrakrunConfig":
         config = configparser.ConfigParser()
         config.read(filename)
-        return DrakrunConfig(**{section: {**config[section]} for section in config.sections()})
+        return DrakrunConfig(
+            **{section: {**config[section]} for section in config.sections()}
+        )
 
 
 def load_config() -> DrakrunConfig:

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -1,57 +1,85 @@
-import json
-import os
-from dataclasses import dataclass
-from typing import Optional
+import configparser
+from typing import Optional, List, Dict, Any
 
-from dataclasses_json import DataClassJsonMixin
+from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, model_validator
+from typing_extensions import Annotated
+from .paths import CONFIG_PATH
 
-from drakrun.lib.util import safe_delete
-
-ETC_DIR = os.getenv("DRAKRUN_ETC_DIR") or "/etc/drakrun"
-VM_CONFIG_DIR = os.path.join(ETC_DIR, "configs")
-
-
-LIB_DIR = os.getenv("DRAKRUN_LIB_DIR") or "/var/lib/drakrun"
-PROFILE_DIR = os.path.join(LIB_DIR, "profiles")
-RUNTIME_FILE = os.path.join(PROFILE_DIR, "runtime.json")
-APISCOUT_PROFILE_DIR = os.path.join(LIB_DIR, "apiscout_profile")
-VOLUME_DIR = os.path.join(LIB_DIR, "volumes")
+CommaSeparatedStrList = Annotated[
+    List[str],
+    BeforeValidator(lambda v: [el.strip() for el in v.split(",") if el.strip()])
+]
 
 
-@dataclass
-class InstallInfo(DataClassJsonMixin):
-    storage_backend: str
-    disk_size: str
-    iso_path: str
-    enable_unattended: bool
-    vcpus: int = 2
-    memory: int = 3072
-    zfs_tank_name: Optional[str] = None
-    lvm_volume_group: Optional[str] = None
-    iso_sha256: Optional[str] = None
+class RedisConfigSection(BaseModel):
+    host: str
+    port: int
 
-    INSTALL_FILE_PATH = os.path.join(ETC_DIR, "install.json")
+
+class MinioConfigSection(BaseModel):
+    address: str
+    bucket: str
+    secure: bool
+    access_key: str
+    secret_key: str
+
+
+class DrakrunConfigSection(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+
+    raw_memory_dump: bool = Field(default=False)
+    net_enable: bool = Field(default=False)
+    out_interface: Optional[str] = Field(default=None)
+    dns_server: str = Field(default="8.8.8.8")
+    syscall_filter: Optional[str] = Field(default=None)
+    enable_ipt: bool = Field(default=False)
+    analysis_timeout: int = Field(default=10*60)
+    analysis_low_timeout: int = Field(default=10*60)
+    use_root_uid: bool = Field(default=False)
+    anti_hammering_threshold: int = Field(default=0)
+    attach_profiles: bool = Field(default=False)
+    attach_apiscout_profile: bool = Field(default=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def default_low_timeout(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        # If analysis_low_timeout defined separately: leave it as is
+        if "analysis_low_timeout" in data and data["analysis_low_timeout"]:
+            return data
+        # If not defined but analysis_timeout defined: map timeout to low_timeout
+        if "analysis_timeout" in data:
+            return {"analysis_low_timeout": data["analysis_timeout"], **data}
+        # If also not defined: use defaults
+        return data
+
+
+class DrakvufPluginsConfigSection(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+
+    # TODO: provide default list of plugins
+    # TODO: validate things like "codemon" must appear with "ipt"
+    # TODO: let's disallow 'no plugins', it's useless and it's not easy to turn off all plugins
+    # TODO: finally, let's make a method that allows to get a list to be used for given priority
+    all: CommaSeparatedStrList
+    low: CommaSeparatedStrList
+    normal: CommaSeparatedStrList
+    high: CommaSeparatedStrList
+
+
+class DrakrunConfig(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+
+    redis: RedisConfigSection
+    minio: MinioConfigSection
+    drakrun: DrakrunConfigSection
+    drakvuf_plugins: DrakvufPluginsConfigSection
 
     @staticmethod
-    def load() -> "InstallInfo":
-        """Reads and parses install.json file"""
-        with open(InstallInfo.INSTALL_FILE_PATH, "r") as f:
-            return InstallInfo.from_json(f.read())
+    def load_from_file(filename: str) -> "DrakrunConfig":
+        config = configparser.ConfigParser()
+        config.read(filename)
+        return DrakrunConfig(**{section: {**config[section]} for section in config.sections()})
 
-    @staticmethod
-    def try_load() -> Optional["InstallInfo"]:
-        """Tries to load install.json of fails with None"""
-        try:
-            return InstallInfo.load()
-        except FileNotFoundError:
-            return None
 
-    @staticmethod
-    def delete():
-        if not safe_delete(InstallInfo.INSTALL_FILE_PATH):
-            raise Exception("install.json not deleted")
-
-    def save(self):
-        """Serializes self and writes to install.json"""
-        with open(InstallInfo.INSTALL_FILE_PATH, "w") as f:
-            f.write(json.dumps(self.to_dict(), indent=4))
+def load_config() -> DrakrunConfig:
+    return DrakrunConfig.load_from_file(CONFIG_PATH)

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -1,13 +1,20 @@
 import configparser
 from typing import Optional, List
 
-from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, computed_field
+from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, computed_field, field_validator
 from typing_extensions import Annotated
 from .paths import CONFIG_PATH
 
 CommaSeparatedStrList = Annotated[
     List[str],
     BeforeValidator(lambda v: [el.strip() for el in v.split(",") if el.strip()])
+]
+
+DEFAULT_PLUGINS = [
+    "apimon", "bsodmon", "clipboardmon", "cpuidmon", "crashmon", "debugmon",
+    "delaymon", "exmon", "filedelete", "filetracer", "librarymon", "memdump",
+    "procdump", "procmon", "regmon", "rpcmon", "ssdtmon", "syscalls", "tlsmon",
+    "windowmon", "wmimon",
 ]
 
 
@@ -56,10 +63,14 @@ class DrakvufPluginsConfigSection(BaseModel):
     # TODO: validate things like "codemon" must appear with "ipt"
     # TODO: let's disallow 'no plugins', it's useless and it's not easy to turn off all plugins
     # TODO: finally, let's make a method that allows to get a list to be used for given priority
-    all: CommaSeparatedStrList = Field(validation_alias="_all_")
+    all: CommaSeparatedStrList = Field(validation_alias="_all_", default_factory=lambda: list(DEFAULT_PLUGINS))
     low: CommaSeparatedStrList
     normal: CommaSeparatedStrList
     high: CommaSeparatedStrList
+
+    @field_validator("all", "low", "normal", "high", mode="after")
+    def validate_plugin_list(self, plugin_list: List[str]) -> List[str]:
+        ...
 
 
 class DrakrunConfig(BaseModel):

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -46,7 +46,7 @@ class RedisConfigSection(BaseModel):
 
 class MinioConfigSection(BaseModel):
     address: str
-    bucket: str
+    bucket: Optional[str] = Field(default=None)
     secure: bool
     access_key: str
     secret_key: str
@@ -73,8 +73,8 @@ class DrakvufPluginsConfigSection(BaseModel):
     all: CommaSeparatedStrList = Field(
         validation_alias="_all_", default_factory=lambda: list(DEFAULT_PLUGINS)
     )
-    low: CommaSeparatedStrList
-    high: CommaSeparatedStrList
+    low: Optional[CommaSeparatedStrList] = Field(default=None)
+    high: Optional[CommaSeparatedStrList] = Field(default=None)
 
     @field_validator("all", mode="after")
     @classmethod

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -84,7 +84,7 @@ class DrakvufPluginsConfigSection(BaseModel):
         return plugin_list
 
     def get_plugin_list(self, quality: str = "high") -> List[str]:
-        if quality not in self.model_fields_set:
+        if quality not in ["all", "low", "high"]:
             raise ValueError(f"'{quality}' is not a valid feed quality level")
         priority_plugin_list = getattr(self, quality)
         if priority_plugin_list:

--- a/drakrun/drakrun/lib/install_info.py
+++ b/drakrun/drakrun/lib/install_info.py
@@ -1,0 +1,46 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from dataclasses_json import DataClassJsonMixin
+from .paths import ETC_DIR
+from .util import safe_delete
+
+@dataclass
+class InstallInfo(DataClassJsonMixin):
+    storage_backend: str
+    disk_size: str
+    iso_path: str
+    enable_unattended: bool
+    vcpus: int = 2
+    memory: int = 3072
+    zfs_tank_name: Optional[str] = None
+    lvm_volume_group: Optional[str] = None
+    iso_sha256: Optional[str] = None
+
+    INSTALL_FILE_PATH = os.path.join(ETC_DIR, "install.json")
+
+    @staticmethod
+    def load() -> "InstallInfo":
+        """Reads and parses install.json file"""
+        with open(InstallInfo.INSTALL_FILE_PATH, "r") as f:
+            return InstallInfo.from_json(f.read())
+
+    @staticmethod
+    def try_load() -> Optional["InstallInfo"]:
+        """Tries to load install.json of fails with None"""
+        try:
+            return InstallInfo.load()
+        except FileNotFoundError:
+            return None
+
+    @staticmethod
+    def delete():
+        if not safe_delete(InstallInfo.INSTALL_FILE_PATH):
+            raise Exception("install.json not deleted")
+
+    def save(self):
+        """Serializes self and writes to install.json"""
+        with open(InstallInfo.INSTALL_FILE_PATH, "w") as f:
+            f.write(json.dumps(self.to_dict(), indent=4))

--- a/drakrun/drakrun/lib/install_info.py
+++ b/drakrun/drakrun/lib/install_info.py
@@ -4,8 +4,10 @@ from dataclasses import dataclass
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
+
 from .paths import ETC_DIR
 from .util import safe_delete
+
 
 @dataclass
 class InstallInfo(DataClassJsonMixin):

--- a/drakrun/drakrun/lib/paths.py
+++ b/drakrun/drakrun/lib/paths.py
@@ -1,9 +1,9 @@
 import os
 
-ETC_DIR = os.getenv("DRAKRUN_ETC_DIR") or "/etc/drakrun"
+ETC_DIR = "/etc/drakrun"
 VM_CONFIG_DIR = os.path.join(ETC_DIR, "configs")
 
-LIB_DIR = os.getenv("DRAKRUN_LIB_DIR") or "/var/lib/drakrun"
+LIB_DIR = "/var/lib/drakrun"
 PROFILE_DIR = os.path.join(LIB_DIR, "profiles")
 RUNTIME_FILE = os.path.join(PROFILE_DIR, "runtime.json")
 APISCOUT_PROFILE_DIR = os.path.join(LIB_DIR, "apiscout_profile")

--- a/drakrun/drakrun/lib/paths.py
+++ b/drakrun/drakrun/lib/paths.py
@@ -1,0 +1,11 @@
+import os
+
+ETC_DIR = os.getenv("DRAKRUN_ETC_DIR") or "/etc/drakrun"
+VM_CONFIG_DIR = os.path.join(ETC_DIR, "configs")
+
+LIB_DIR = os.getenv("DRAKRUN_LIB_DIR") or "/var/lib/drakrun"
+PROFILE_DIR = os.path.join(LIB_DIR, "profiles")
+RUNTIME_FILE = os.path.join(PROFILE_DIR, "runtime.json")
+APISCOUT_PROFILE_DIR = os.path.join(LIB_DIR, "apiscout_profile")
+VOLUME_DIR = os.path.join(LIB_DIR, "volumes")
+CONFIG_PATH = os.path.join(ETC_DIR, "config.ini")

--- a/drakrun/drakrun/lib/storage.py
+++ b/drakrun/drakrun/lib/storage.py
@@ -8,7 +8,8 @@ import subprocess
 import time
 from typing import Tuple
 
-from drakrun.lib.config import VOLUME_DIR, InstallInfo
+from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.paths import VOLUME_DIR
 from drakrun.lib.util import safe_delete
 
 log = logging.getLogger(__name__)

--- a/drakrun/drakrun/lib/vm.py
+++ b/drakrun/drakrun/lib/vm.py
@@ -6,7 +6,8 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from drakrun.lib.config import ETC_DIR, LIB_DIR, VM_CONFIG_DIR, VOLUME_DIR, InstallInfo
+from drakrun.lib.config import InstallInfo
+from drakrun.lib.paths import ETC_DIR, LIB_DIR, VM_CONFIG_DIR, VOLUME_DIR
 from drakrun.lib.storage import StorageBackendBase, get_storage_backend
 from drakrun.lib.util import safe_delete
 

--- a/drakrun/drakrun/lib/vm.py
+++ b/drakrun/drakrun/lib/vm.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from drakrun.lib.config import InstallInfo
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.paths import ETC_DIR, LIB_DIR, VM_CONFIG_DIR, VOLUME_DIR
 from drakrun.lib.storage import StorageBackendBase, get_storage_backend
 from drakrun.lib.util import safe_delete

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -51,16 +51,6 @@ from drakrun.lib.util import RuntimeInfo, file_sha256, graceful_exit
 from drakrun.lib.vm import VirtualMachine, generate_vm_conf
 from drakrun.version import __version__ as DRAKRUN_VERSION
 
-# fmt: off
-# List of default plugins, and at the same time list of all supported plugins.
-SUPPORTED_PLUGINS = [
-    "apimon", "bsodmon", "clipboardmon", "cpuidmon", "crashmon", "debugmon",
-    "delaymon", "exmon", "filedelete", "filetracer", "librarymon", "memdump",
-    "procdump", "procmon", "regmon", "rpcmon", "ssdtmon", "syscalls", "tlsmon",
-    "windowmon", "wmimon",
-]
-# fmt: on
-
 MAX_TASK_TIMEOUT = 60 * 20  # Never run samples for longer than this
 
 log = logging.getLogger(__name__)

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -27,20 +27,20 @@ from karton.core import Config, Karton, LocalResource, Resource, Task
 
 from drakrun.lib.bindings.xen import get_xen_info, parse_xen_commandline
 from drakrun.lib.config import load_config
+from drakrun.lib.drakpdb import dll_file_list
+from drakrun.lib.injector import Injector
 from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.networking import (
+    setup_vm_network,
+    start_dnsmasq,
+    start_tcpdump_collector,
+)
 from drakrun.lib.paths import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
     PROFILE_DIR,
     RUNTIME_FILE,
     VOLUME_DIR,
-)
-from drakrun.lib.drakpdb import dll_file_list
-from drakrun.lib.injector import Injector
-from drakrun.lib.networking import (
-    setup_vm_network,
-    start_dnsmasq,
-    start_tcpdump_collector,
 )
 from drakrun.lib.sample_startup import (
     get_sample_entrypoints,

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -26,13 +26,13 @@ import magic
 from karton.core import Config, Karton, LocalResource, Resource, Task
 
 from drakrun.lib.bindings.xen import get_xen_info, parse_xen_commandline
-from drakrun.lib.config import (
+from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.paths import (
     APISCOUT_PROFILE_DIR,
     ETC_DIR,
     PROFILE_DIR,
     RUNTIME_FILE,
     VOLUME_DIR,
-    InstallInfo,
 )
 from drakrun.lib.drakpdb import dll_file_list
 from drakrun.lib.injector import Injector

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from IPython import embed
 
 from drakrun.draksetup import insert_cd
-from drakrun.lib.config import ETC_DIR, PROFILE_DIR, RUNTIME_FILE, InstallInfo
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.injector import Injector
 from drakrun.lib.networking import (
     delete_vm_network,
@@ -17,6 +17,7 @@ from drakrun.lib.networking import (
     setup_vm_network,
     start_dnsmasq,
 )
+from drakrun.lib.paths import ETC_DIR, PROFILE_DIR, RUNTIME_FILE
 from drakrun.lib.storage import get_storage_backend
 from drakrun.lib.util import RuntimeInfo, graceful_exit
 from drakrun.lib.vm import FIRST_CDROM_DRIVE, VirtualMachine, generate_vm_conf

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -9,8 +9,8 @@ from textwrap import dedent
 from IPython import embed
 
 from drakrun.draksetup import insert_cd
-from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.injector import Injector
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.networking import (
     delete_vm_network,
     find_default_interface,

--- a/drakrun/drakrun/regression.py
+++ b/drakrun/drakrun/regression.py
@@ -15,7 +15,7 @@ from malduck.extractor import ExtractManager, ExtractorModules
 from mwdblib import MWDB
 from tqdm import tqdm
 
-from drakrun.lib.config import ETC_DIR
+from drakrun.lib.paths import ETC_DIR
 from drakrun.version import __version__ as DRAKRUN_VERSION
 
 

--- a/drakrun/drakrun/test/test_lvm.py
+++ b/drakrun/drakrun/test/test_lvm.py
@@ -8,7 +8,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from common_utils import tool_exists
 
-from drakrun.lib.config import InstallInfo
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.storage import LvmStorageBackend
 from drakrun.lib.util import safe_delete
 

--- a/drakrun/drakrun/test/test_vm.py
+++ b/drakrun/drakrun/test/test_vm.py
@@ -8,7 +8,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from common_utils import remove_files, tool_exists
 
-from drakrun.lib.config import InstallInfo
+from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.util import safe_delete
 from drakrun.lib.vm import VirtualMachine
 

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -19,3 +19,6 @@ mwdblib==3.4.1
 # Something went wrong in 4.3.0 package
 yara-python<4.3.0
 mslex==1.1.0
+pydantic==2.6.4
+# Peer dependency of Pydantic
+typing-extensions

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -121,22 +121,15 @@ def drakmon_setup():
             else:
                 pip_install(ssh, ["./" + d.name])
 
-        # Save default config
-        ssh.run("mkdir /etc/drakrun/")
-
-        ssh.run(f"""
-cat > /etc/drakrun/config.ini <<EOF
-[minio]
-address={MINIO_HOST}
-secure=0
-access_key={MINIO_ACCESS_KEY}
-secret_key={MINIO_SECRET_KEY}
-EOF""")
-
         # Import snapshot
         assert SNAPSHOT_VERSION is not None
-        ssh.run(f"draksetup snapshot import --bucket snapshots --name {SNAPSHOT_VERSION} --full")
         ssh.run(f"draksetup init --envfile /etc/drakcore/minio.env")
+        ssh.run(f'DRAKRUN_MINIO_ADDRESS="{MINIO_HOST}" '
+                f'DRAKRUN_MINIO_SECURE=0 '
+                f'DRAKRUN_MINIO_ACCESS_KEY="{MINIO_ACCESS_KEY}" '
+                f'DRAKRUN_MINIO_SECRET_KEY="{MINIO_ACCESS_KEY}" '
+                f'draksetup snapshot import --bucket snapshots --name {SNAPSHOT_VERSION} --full')
+
 
         # Shut up QEMU
         ssh.run("ln -s /dev/null /root/SW_DVD5_Win_Pro_7w_SP1_64BIT_Polish_-2_MLF_X17-59386.ISO")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -130,7 +130,6 @@ def drakmon_setup():
                 f'DRAKRUN_MINIO_SECRET_KEY="{MINIO_SECRET_KEY}" '
                 f'draksetup snapshot import --bucket snapshots --name {SNAPSHOT_VERSION} --full')
 
-
         # Shut up QEMU
         ssh.run("ln -s /dev/null /root/SW_DVD5_Win_Pro_7w_SP1_64BIT_Polish_-2_MLF_X17-59386.ISO")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -127,7 +127,7 @@ def drakmon_setup():
         ssh.run(f'DRAKRUN_MINIO_ADDRESS="{MINIO_HOST}" '
                 f'DRAKRUN_MINIO_SECURE=0 '
                 f'DRAKRUN_MINIO_ACCESS_KEY="{MINIO_ACCESS_KEY}" '
-                f'DRAKRUN_MINIO_SECRET_KEY="{MINIO_ACCESS_KEY}" '
+                f'DRAKRUN_MINIO_SECRET_KEY="{MINIO_SECRET_KEY}" '
                 f'draksetup snapshot import --bucket snapshots --name {SNAPSHOT_VERSION} --full')
 
 


### PR DESCRIPTION
In current version we use Karton config while `drakrun.lib` should be independent from Karton. In addition: knowledge about default values and relationships between configuration fields is dispersed in drakrun modules, mainly in main.py

In this PR I try to map current configuration layout using Pydantic to provide single, coherent object that can be used in various drakrun components.