### PR TITLE
Drop support for Debian Buster, set minimum requirement to Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,6 @@ jobs:
       matrix:
         include:
           - distro: debian
-            version: buster
-          - distro: debian
             version: bullseye
     runs-on: ubuntu-latest
     container: "${{ matrix.distro }}:${{matrix.version}}"
@@ -149,8 +147,6 @@ jobs:
       matrix:
         include:
           - distro: debian
-            version: buster
-          - distro: debian
             version: bullseye
     runs-on: ubuntu-latest
     container: "${{ matrix.distro }}:${{matrix.version}}"
@@ -198,9 +194,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: debian
-            version: buster
-            version_number: 10
           - distro: debian
             version: bullseye
             version_number: 11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
             version: bullseye
             version_number: 11
     runs-on: self-hosted
-    container: python:3.8-buster
+    container: python:3.8-bullseye
     # Prevent concurrent jobs trying to reach the same VM
     concurrency: ci-${{ github.ref }}-${{ matrix.distro }}-${{ matrix.version_number }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Download draksetup compiled tools from artifacts
         uses: actions/download-artifact@v3
         with:
-          name: draksetup-tools-debian-buster
+          name: draksetup-tools-debian-bullseye
           path: drakrun/drakrun/tools
       - name: Build drakrun
         run: |

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -13,6 +13,7 @@ setup(
     package_dir={"drakrun": "drakrun"},
     packages=find_packages(),
     include_package_data=True,
+    python_requires=">=3.8",
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Python 3.6 is not supported and it blocks us from dependency upgrades (e.g. ipython #766, pydantic going to be introduced in #878 etc.)

I left `matrix` strategy in case we want to test it on newer Debian versions.