### PR TITLE
Upgrade Karton to v5 and change log handling

### DIFF
--- a/drakrun/drakrun/data/config.ini
+++ b/drakrun/drakrun/data/config.ini
@@ -12,8 +12,6 @@ bucket=karton
 secure=0
 
 ; MinIO access credentials
-; If draksetup is run with --envfile option, these options will be imported
-; from the provided envfile (for example from /etc/drakcore/minio.env)
 access_key=
 secret_key=
 

--- a/drakrun/drakrun/draksetup.py
+++ b/drakrun/drakrun/draksetup.py
@@ -20,7 +20,6 @@ from typing import List, Optional
 
 import click
 import requests
-from minio import Minio
 from minio.error import NoSuchKey
 from tqdm import tqdm
 
@@ -45,6 +44,7 @@ from drakrun.lib.drakpdb import (
 )
 from drakrun.lib.injector import Injector
 from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.minio import get_minio_client
 from drakrun.lib.networking import (
     delete_all_vm_networks,
     delete_legacy_iptables,
@@ -962,16 +962,6 @@ def mount(iso_path, domain_name):
     """
     iso_path_full = os.path.abspath(iso_path)
     insert_cd(domain_name, FIRST_CDROM_DRIVE, iso_path_full)
-
-
-def get_minio_client(config: DrakrunConfig):
-    minio_cfg = config.minio
-    return Minio(
-        endpoint=minio_cfg.address,
-        access_key=minio_cfg.access_key,
-        secret_key=minio_cfg.secret_key,
-        secure=minio_cfg.secure,
-    )
 
 
 @click.group(help="Manage VM raw memory pre-sample dumps")

--- a/drakrun/drakrun/lib/config.py
+++ b/drakrun/drakrun/lib/config.py
@@ -68,6 +68,15 @@ class DrakrunConfigSection(BaseModel):
     anti_hammering_threshold: int = Field(default=0)
     attach_profiles: bool = Field(default=False)
     attach_apiscout_profile: bool = Field(default=False)
+    xen_cmdline_check: str = Field(default="fail")
+
+    @field_validator("xen_cmdline_check", mode="after")
+    @classmethod
+    def xen_cmdline_check_validator(cls, v: str):
+        allowed_choices = ["fail", "ignore", "no"]
+        if v not in allowed_choices:
+            raise ValueError(f"must be one of: {allowed_choices}")
+        return v
 
 
 class DrakvufPluginsConfigSection(BaseModel):

--- a/drakrun/drakrun/lib/minio.py
+++ b/drakrun/drakrun/lib/minio.py
@@ -1,0 +1,18 @@
+"""
+Minio utilities. In future versions we plan to move to more generic S3 binding
+as we did in Karton v5, but right now we use py-minio directly.
+"""
+
+from minio import Minio
+
+from .config import DrakrunConfig
+
+
+def get_minio_client(config: DrakrunConfig):
+    minio_cfg = config.minio
+    return Minio(
+        endpoint=minio_cfg.address,
+        access_key=minio_cfg.access_key,
+        secret_key=minio_cfg.secret_key,
+        secure=minio_cfg.secure,
+    )

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
-import functools
+import contextlib
 import hashlib
 import json
 import logging
@@ -9,9 +9,7 @@ import os
 import pathlib
 import shutil
 import socket
-import sys
 import tempfile
-from io import StringIO
 from pathlib import Path
 from typing import Dict, Optional, Union, cast
 
@@ -44,64 +42,21 @@ MAX_TASK_TIMEOUT = 60 * 20  # Never run samples for longer than this
 log = logging.getLogger(__name__)
 
 
-class LocalLogBuffer(logging.Handler):
-    FIELDS = (
-        "levelname",
-        "message",
-        "created",
-    )
-
-    def __init__(self):
-        super().__init__()
-        self.buffer = []
-
-    def emit(self, record):
-        entry = {k: v for (k, v) in record.__dict__.items() if k in self.FIELDS}
-        self.buffer.append(entry)
+class XenCommandlineCheckError(Exception):
+    """
+    Xen command line was incorrect and drakrun was instructed to fail in that case
+    """
 
 
-# TODO: Deduplicate this, once we have shared code between drakcore and drakrun
-def with_logs(object_name):
-    def decorator(method):
-        @functools.wraps(method)
-        def wrapper(self: Karton, *args, **kwargs):
-            handler = LocalLogBuffer()
-            try:
-                # Register new log handler
-                self.log.addHandler(handler)
-                method(self, *args, **kwargs)
-            except Exception:
-                self.log.exception("Analysis failed")
-                raise
-            finally:
-                # Unregister local handler
-                self.log.removeHandler(handler)
-                try:
-                    buffer = StringIO()
-                    for idx, entry in enumerate(handler.buffer):
-                        if idx > 0:
-                            buffer.write("\n")
-                        buffer.write(json.dumps(entry))
-
-                    res = LocalResource(
-                        object_name, buffer.getvalue(), bucket="drakrun"
-                    )
-                    task_uid = (
-                        self.current_task.payload.get("override_uid")
-                        or self.current_task.uid
-                    )
-                    res._uid = f"{task_uid}/{res.name}"
-
-                    # Karton rejects empty resources
-                    # Ensure that we upload it only when some data was actually generated
-                    if buffer.tell() > 0:
-                        res.upload(self.backend)
-                except Exception:
-                    self.log.exception("Failed to upload analysis logs")
-
-        return wrapper
-
-    return decorator
+@contextlib.contextmanager
+def scoped_file_logger(filename: pathlib.Path, logger: logging.Logger):
+    handler = logging.FileHandler(filename, mode="w")
+    try:
+        logger.addHandler(handler)
+        yield
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
 
 
 def get_sample_sha256(sample_path: pathlib.Path) -> str:
@@ -119,21 +74,32 @@ class DrakrunKarton(Karton):
     version = DRAKRUN_VERSION
     identity = "karton.drakrun-prod"
     filters = [
-        {"type": "sample", "stage": "recognized", "platform": "win32"},
-        {"type": "sample", "stage": "recognized", "platform": "win64"},
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "platform": "win32",
+            "execute": "!False",
+        },
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "platform": "win64",
+            "execute": "!False",
+        },
     ]
 
-    def __init__(self, config: Config, instance_id: int) -> None:
-        super().__init__(config)
+    def __init__(self, config: Config, instance_id: int, *args, **kwargs) -> None:
+        super().__init__(config, *args, **kwargs)
         self.drakconfig = load_config()
         self.instance_id = instance_id
         self.install_info = InstallInfo.load()
         self.runtime_info = RuntimeInfo.load(RUNTIME_FILE)
 
-        generate_vm_conf(self.install_info, self.instance_id)
+        xen_cmdline_check = self.drakconfig.drakrun.xen_cmdline_check
+        if xen_cmdline_check != "no":
+            validate_xen_commandline(xen_cmdline_check == "ignore")
 
-        if not self.backend.minio.bucket_exists("drakrun"):
-            self.backend.minio.make_bucket(bucket_name="drakrun")
+        generate_vm_conf(self.install_info, self.instance_id)
 
         self.log.info("Calculating snapshot hash...")
         self.snapshot_sha256 = file_sha256(os.path.join(VOLUME_DIR, "snapshot.sav"))
@@ -182,9 +148,8 @@ class DrakrunKarton(Karton):
                 object_name = os.path.join(analysis_uid, subdir, fn)
                 res_name = os.path.join(subdir, fn)
                 resource = LocalResource(
-                    name=res_name, bucket="drakrun", path=file_path
+                    name=res_name, bucket="drakrun", path=file_path, uid=object_name
                 )
-                resource._uid = object_name
                 yield resource
             elif os.path.isdir(file_path):
                 yield from self.upload_artifacts(
@@ -266,13 +231,7 @@ class DrakrunKarton(Karton):
         output_dir.mkdir()
         return output_dir
 
-    @with_logs("drakrun.log")
     def process_task(self, task: Task) -> None:
-        # Tasks with {"execute": false} header are not scheduled for execution.
-        # When the header is missing, the default is to execute the sample.
-        if not task.headers.get("execute", True):
-            return
-
         timeout = self.timeout_for_task(task)
         if timeout > MAX_TASK_TIMEOUT:
             self.log.error(
@@ -283,113 +242,128 @@ class DrakrunKarton(Karton):
 
         sample: RemoteResource = cast(RemoteResource, task.get_resource("sample"))
         output_dir = self._prepare_analysis_directory()
+        drakrun_log_path = output_dir / "drakrun.log"
 
-        sample_path = self.analysis_dir / "sample"
-        sample.download_to_file(str(sample_path))
-        sha256sum = get_sample_sha256(sample_path)
+        with scoped_file_logger(drakrun_log_path, logging.getLogger()):
+            sample_path = self.analysis_dir / "sample"
+            sample.download_to_file(str(sample_path))
+            sha256sum = get_sample_sha256(sample_path)
 
-        self.log.info(f"Running on: {socket.gethostname()}")
-        self.log.info(f"Sample SHA256: {sha256sum}")
-        self.log.info(f"Analysis UID: {self.analysis_uid}")
-        self.log.info(f"Snapshot SHA256: {self.snapshot_sha256}")
+            self.log.info(f"Running on: {socket.gethostname()}")
+            self.log.info(f"Sample SHA256: {sha256sum}")
+            self.log.info(f"Analysis UID: {self.analysis_uid}")
+            self.log.info(f"Snapshot SHA256: {self.snapshot_sha256}")
 
-        magic_output = magic.from_file(sample_path)
+            magic_output = magic.from_file(sample_path)
 
-        # TODO: unify this default path somewhere
-        hooks_path = pathlib.Path(ETC_DIR) / "hooks.txt"
-        # If task contains 'custom_hooks' override local defaults
-        if task.has_payload("custom_hooks"):
-            hooks_path = self.analysis_dir / "hooks.txt"
-            custom_hooks = cast(RemoteResource, task.get_resource("custom_hooks"))
-            custom_hooks.download_to_file(str(hooks_path))
+            # TODO: unify this default path somewhere
+            hooks_path = pathlib.Path(ETC_DIR) / "hooks.txt"
+            # If task contains 'custom_hooks' override local defaults
+            if task.has_payload("custom_hooks"):
+                hooks_path = self.analysis_dir / "hooks.txt"
+                custom_hooks = cast(RemoteResource, task.get_resource("custom_hooks"))
+                custom_hooks.download_to_file(str(hooks_path))
 
-        user_start_command = task.payload.get("start_command")
-        extension = task.headers.get("extension")
+            user_start_command = task.payload.get("start_command")
+            extension = task.headers.get("extension")
 
-        # You can request a subset of supported plugins in task payload
-        task_quality = self.current_task.headers.get("quality", "high")
-        supported_plugins = self.drakconfig.drakvuf_plugins.get_plugin_list(
-            task_quality
-        )
-        requested_plugins = self.current_task.payload.get(
-            "plugins", self.drakconfig.drakvuf_plugins.get_plugin_list(task_quality)
-        )
-        plugins = list(set(supported_plugins) & set(requested_plugins))
-        self.update_vnc_info()
+            # You can request a subset of supported plugins in task payload
+            task_quality = self.current_task.headers.get("quality", "high")
+            supported_plugins = self.drakconfig.drakvuf_plugins.get_plugin_list(
+                task_quality
+            )
+            requested_plugins = self.current_task.payload.get(
+                "plugins", self.drakconfig.drakvuf_plugins.get_plugin_list(task_quality)
+            )
+            plugins = list(set(supported_plugins) & set(requested_plugins))
+            self.update_vnc_info()
 
-        metadata = {
-            "analysis_uid": self.analysis_uid,
-            "sample_sha256": sha256sum,
-            "snapshot_sha256": self.snapshot_sha256,
-            "magic_output": magic_output,
-        }
+            metadata = {
+                "analysis_uid": self.analysis_uid,
+                "sample_sha256": sha256sum,
+                "snapshot_sha256": self.snapshot_sha256,
+                "magic_output": magic_output,
+            }
 
-        create_or_update_analysis_status(
-            self.backend.redis, self.analysis_uid, AnalysisStatus.STARTED, metadata
-        )
+            create_or_update_analysis_status(
+                self.backend.redis, self.analysis_uid, AnalysisStatus.STARTED, metadata
+            )
 
-        analysis_options = AnalysisOptions(
-            sample_path=sample_path,
-            vm_id=self.instance_id,
-            output_dir=output_dir,
-            plugins=plugins,
-            timeout=timeout,
-            hooks_path=hooks_path,
-            start_command=user_start_command,
-            extension=extension,
-            sample_filename=sample.name,
-            dns_server=self.drakconfig.drakrun.dns_server,
-            out_interface=self.drakconfig.drakrun.out_interface,
-            net_enable=self.drakconfig.drakrun.net_enable,
-            anti_hammering_threshold=self.drakconfig.drakrun.anti_hammering_threshold,
-            syscall_filter=self.drakconfig.drakrun.syscall_filter,
-            raw_memory_dump=self.drakconfig.drakrun.raw_memory_dump,
-        )
+            analysis_options = AnalysisOptions(
+                sample_path=sample_path,
+                vm_id=self.instance_id,
+                output_dir=output_dir,
+                plugins=plugins,
+                timeout=timeout,
+                hooks_path=hooks_path,
+                start_command=user_start_command,
+                extension=extension,
+                sample_filename=sample.name,
+                dns_server=self.drakconfig.drakrun.dns_server,
+                out_interface=self.drakconfig.drakrun.out_interface,
+                net_enable=self.drakconfig.drakrun.net_enable,
+                anti_hammering_threshold=self.drakconfig.drakrun.anti_hammering_threshold,
+                syscall_filter=self.drakconfig.drakrun.syscall_filter,
+                raw_memory_dump=self.drakconfig.drakrun.raw_memory_dump,
+            )
 
-        max_attempts = 3
-        for attempt in range(max_attempts):
-            try:
-                self.log.info(
-                    f"Trying to analyze sample (attempt {attempt+1}/{max_attempts})"
-                )
-                analysis_metadata = analyze_sample(analysis_options)
-                break
-            except UnretryableAnalysisError:
-                self.log.exception("Analysis attempt failed with unretryable error")
-                raise
-            except Exception:
-                self.log.exception("Analysis attempt failed. Retrying...")
-            # Clean output dir before next try
-            self._ensure_clean_output_dir()
-        else:
-            raise RuntimeError(f"Giving up after {max_attempts} failures...")
+            max_attempts = 3
+            for attempt in range(max_attempts):
+                try:
+                    self.log.info(
+                        f"Trying to analyze sample (attempt {attempt+1}/{max_attempts})"
+                    )
+                    analysis_metadata = analyze_sample(analysis_options)
+                    break
+                except UnretryableAnalysisError:
+                    self.log.exception("Analysis attempt failed with unretryable error")
+                    raise
+                except Exception:
+                    self.log.exception("Analysis attempt failed. Retrying...")
+                # Clean output dir before next try
+                self._ensure_clean_output_dir()
+            else:
+                raise RuntimeError(f"Giving up after {max_attempts} failures...")
 
-        metadata = {**metadata, **analysis_metadata}
-        (output_dir / "metadata.json").write_text(json.dumps(metadata))
+            metadata = {**metadata, **analysis_metadata}
+            (output_dir / "metadata.json").write_text(json.dumps(metadata))
 
-        quality = task.headers.get("quality", "high")
-        self.send_raw_analysis(
-            sample,
-            str(output_dir),
-            metadata,
-            quality,
-        )
+            quality = task.headers.get("quality", "high")
+            self.send_raw_analysis(
+                sample,
+                str(output_dir),
+                metadata,
+                quality,
+            )
 
-        update_analysis_status(
-            self.backend.redis, self.analysis_uid, AnalysisStatus.FINISHED, metadata
-        )
+            update_analysis_status(
+                self.backend.redis, self.analysis_uid, AnalysisStatus.FINISHED, metadata
+            )
 
     def process(self, task: Task) -> None:
-        # TODO: Well, drakcore doesn't know what to do
-        #       when task is crashed. We need this awful
-        #       hack for now
         try:
             self.process_task(task)
         except Exception:
             update_analysis_status(
                 self.backend.redis, self.analysis_uid, AnalysisStatus.CRASHED
             )
-            return
+            raise
+
+    @classmethod
+    def args_parser(cls) -> argparse.ArgumentParser:
+        parser = super().args_parser()
+        parser.add_argument("instance", type=int, help="Instance identifier")
+        return parser
+
+    @classmethod
+    def karton_from_args(cls, args: Optional[argparse.Namespace] = None) -> None:
+        if args is None:
+            parser = cls.args_parser()
+            args = parser.parse_args()
+        conf_path = os.path.join(ETC_DIR, "config.ini")
+        config = Config(path=args.config_file or conf_path)
+        cls.config_from_args(config, args)
+        return cls(config=config, instance_id=args.instance)
 
 
 def validate_xen_commandline(ignore_failure: bool) -> None:
@@ -447,29 +421,8 @@ def validate_xen_commandline(ignore_failure: bool) -> None:
             log.error(
                 "Exitting due to above warnings. Please ensure that you are using recommended Xen's command line."
             )
-            sys.exit(1)
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Kartonized drakrun <3")
-    parser.add_argument("instance", type=int, help="Instance identifier")
-    args = parser.parse_args()
-
-    conf_path = os.path.join(ETC_DIR, "config.ini")
-    conf = Config(conf_path)
-
-    if not conf.config.get("minio", "access_key").strip():
-        log.warning(
-            f"Detected blank value for minio access_key in {conf_path}. "
-            "This service may not work properly."
-        )
-
-    xen_cmdline_check = conf.config.get("drakrun", "xen_cmdline_check", fallback="fail")
-    validate_xen_commandline(xen_cmdline_check == "ignore")
-
-    c = DrakrunKarton(conf, args.instance)
-    c.loop()
+            raise XenCommandlineCheckError()
 
 
 if __name__ == "__main__":
-    main()
+    DrakrunKarton.main()

--- a/drakrun/drakrun/web/app.py
+++ b/drakrun/drakrun/web/app.py
@@ -15,14 +15,18 @@ from drakrun.lib.analysis_status import (
     create_analysis_status,
     get_analysis_status_list,
 )
+from drakrun.lib.config import load_config
+from drakrun.lib.minio import get_minio_client
 from drakrun.lib.paths import ETC_DIR
 from drakrun.web.analysis import AnalysisProxy
 
 app = Flask(__name__, static_folder="frontend/build/static")
-conf_path = os.path.join(ETC_DIR, "config.ini")
-conf = Config(conf_path)
-backend = KartonBackend(conf)
-minio = backend.minio
+karton_conf_path = os.path.join(ETC_DIR, "config.ini")
+karton_conf = Config(karton_conf_path)
+backend = KartonBackend(karton_conf)
+
+drakrun_conf = load_config()
+minio = get_minio_client(drakrun_conf)
 
 
 @app.errorhandler(NoSuchKey)
@@ -39,7 +43,7 @@ def add_header(response):
 
 @app.route("/upload", methods=["POST"])
 def upload():
-    producer = Producer(conf)
+    producer = Producer(karton_conf)
 
     with NamedTemporaryFile() as f:
         request.files["file"].save(f.name)

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -1,6 +1,6 @@
-karton-core==4.3.0
+karton-core==5.3.4
 minio==5.0.7
-redis==4.4.4
+redis==5.0.3
 pefile==2019.4.18
 # Use pdbparse from master branch
 # current release - 1.5 has troubles parsing some of the PDBs

--- a/drakrun/setup.py
+++ b/drakrun/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={
         "console_scripts": [
-            "drakrun = drakrun.main:main",
+            "drakrun = drakrun.main:DrakrunKarton.main",
             "drakstart = drakrun.analyzer:main",
             "drakpostprocess = drakrun.postprocess:main",
             "draksetup = drakrun.draksetup:main",


### PR DESCRIPTION
- Karton was updated to v5. Karton 5 uses boto3 as S3 binding so we need to make our own `minio.Minio` object when we want to make direct calls to the MinIO instance
- In previous version: logs were collected in memory and then flushed to the file and Karton resource. I changed the behavior to write logs directly to the file using `FileHandler` set on root logger (as we want to collect logs from other components as well)