### PR TITLE
Fix flaky test: DRAKRUN_INP is not guaranteed to be set without network_setup_test

### DIFF
--- a/drakrun/drakrun/test/test_network.py
+++ b/drakrun/drakrun/test/test_network.py
@@ -40,7 +40,7 @@ def iptables_test():
     if not tool_exists("iptables"):
         pytest.skip("iptables does not exist")
 
-    rule = "DRAKRUN_INP -i draktest0 -d 239.255.255.0/24 -j DROP"
+    rule = "INPUT -i draktest0 -d 239.255.255.0/24 -j DROP"
 
     assert not iptable_rule_exists(rule)
 


### PR DESCRIPTION
As it's independent test that doesn't check anything related with `setup_vm_network`, we should use default chains.