### PR TITLE
Fix: drakrun.log handling

### DIFF
--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -261,7 +261,7 @@ class DrakrunKarton(Karton):
         sample: RemoteResource = cast(RemoteResource, task.get_resource("sample"))
         output_dir = self._prepare_analysis_directory()
 
-        with self.persist_drakrun_log(self.analysis_dir):
+        with self.persist_drakrun_log():
             sample_path = self.analysis_dir / "sample"
             sample.download_to_file(str(sample_path))
             sha256sum = get_sample_sha256(sample_path)

--- a/drakrun/drakrun/main.py
+++ b/drakrun/drakrun/main.py
@@ -240,13 +240,14 @@ class DrakrunKarton(Karton):
                 yield
         except Exception:
             # In case of failure: upload drakrun.log artifact
-            log_resource = LocalResource(
-                name="drakrun.log",
-                path=drakrun_log_path,
-                uid=f"{self.analysis_uid}/drakrun.log",
-                bucket="drakrun",
-            )
-            log_resource.upload(self.backend)
+            if drakrun_log_path.exists():
+                log_resource = LocalResource(
+                    name="drakrun.log",
+                    path=drakrun_log_path,
+                    uid=f"{self.analysis_uid}/drakrun.log",
+                    bucket="drakrun",
+                )
+                log_resource.upload(self.backend)
             raise
 
     def process_task(self, task: Task) -> None:


### PR DESCRIPTION
Don't clobber output dir, write drakmon.log to root analysis dir, because analyzer expects that output dir is empty