### PR TITLE
Normalize/remove Unicode characters in file names

### DIFF
--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -12,6 +12,7 @@ import shutil
 import string
 import subprocess
 import time
+import unicodedata
 from typing import List, Optional, Tuple
 
 import magic
@@ -104,9 +105,15 @@ def filename_for_task(options: AnalysisOptions) -> Tuple[str, str]:
     # Make sure the extension is lowercase
     extension = extension.lower()
     # Validate filename provided by user and append proper extension if necessary
-    if options.sample_filename and is_valid_filename(
-        options.sample_filename, platform=Platform.UNIVERSAL
-    ):
+    file_name = options.sample_filename
+    # Normalize/remove Unicode characters as current version of Drakvuf
+    # isn't really good at handling them in logs
+    file_name = (
+        unicodedata.normalize("NFKD", file_name)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+    )
+    if file_name and is_valid_filename(file_name, platform=Platform.UNIVERSAL):
         file_name = options.sample_filename
         if "." not in file_name or file_name.split(".")[-1].lower() != extension:
             file_name += f".{extension}"


### PR DESCRIPTION
Right now, Drakvuf isn't really good at handling Unicode names, leaving them in native encoding and placing directly into JSON string

```
JSON decode error occurred when tried to parse injector's logs. Raw log line: b'{"Plugin": "inject", "TimeStamp": "1720614534.086632", "Method": "WriteFile", "Status": "Success", "ProcessName": "C:\\\\Users\\\\user\\\\Desktop\\\\FV-xxx dasdasd Zapytanie o cen\\304\\231 arbejdsmetodes.bat", "Arguments": "dasdasd Zapytanie o cen\\304\\231 arbejdsmetodes.bat", "InjectedPid": 0, "InjectedTid": 0}\n'
```

As a workaround, this PR converts'/removes Unicode characters into ASCII. If we're left with empty name, random name will be generated.