### PR TITLE
Fix: drakplayground missing import after refactoring

### DIFF
--- a/drakrun/drakrun/draksetup/mount.py
+++ b/drakrun/drakrun/draksetup/mount.py
@@ -1,13 +1,9 @@
 import os
-import subprocess
 
 import click
 
+from drakrun.lib.bindings.xen import xen_insert_cd
 from drakrun.lib.vm import FIRST_CDROM_DRIVE
-
-
-def insert_cd(domain, drive, iso):
-    subprocess.run(["xl", "cd-insert", domain, drive, iso], check=True)
 
 
 @click.command(help="Mount ISO into guest", no_args_is_help=True)
@@ -25,4 +21,4 @@ def mount(iso_path, domain_name):
     Domain can be retrieved by running "xl list" command on the host.
     """
     iso_path_full = os.path.abspath(iso_path)
-    insert_cd(domain_name, FIRST_CDROM_DRIVE, iso_path_full)
+    xen_insert_cd(domain_name, FIRST_CDROM_DRIVE, iso_path_full)

--- a/drakrun/drakrun/lib/bindings/xen.py
+++ b/drakrun/drakrun/lib/bindings/xen.py
@@ -109,3 +109,7 @@ def get_xen_info() -> Dict[str, str]:
         k, v = k.strip(), v.strip()
         elements[k] = v
     return elements
+
+
+def xen_insert_cd(domain, drive, iso):
+    subprocess.run(["xl", "cd-insert", domain, drive, iso], check=True)

--- a/drakrun/drakrun/playground.py
+++ b/drakrun/drakrun/playground.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from IPython import embed
 
-from drakrun.draksetup import insert_cd
+from drakrun.lib.bindings.xen import xen_insert_cd
 from drakrun.lib.injector import Injector
 from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.networking import (
@@ -136,7 +136,7 @@ class DrakmonShell:
 
     def mount(self, local_iso_path, drive=FIRST_CDROM_DRIVE):
         local_iso_path = Path(local_iso_path)
-        insert_cd(self.vm.vm_name, drive, local_iso_path)
+        xen_insert_cd(self.vm.vm_name, drive, local_iso_path)
 
     def run(self, cmd):
         self.injector.create_process(cmd)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/venv/bin/drakplayground", line 5, in <module>
    from drakrun.playground import main
  File "/opt/venv/lib/python3.9/site-packages/drakrun/playground.py", line 12, in <module>
    from drakrun.draksetup import insert_cd
ImportError: cannot import name 'insert_cd' from 'drakrun.draksetup' (/opt/venv/lib/python3.9/site-packages/drakrun/draksetup/__init__.py)
```

Bug introduced in https://github.com/CERT-Polska/drakvuf-sandbox/pull/925