### PR TITLE
Fix: not all 'unrequired' profiles are apivectors profiles

### DIFF
--- a/drakrun/drakrun/draksetup/util/profile_builder.py
+++ b/drakrun/drakrun/draksetup/util/profile_builder.py
@@ -13,12 +13,13 @@ from drakrun.lib.apiscout import (
 from drakrun.lib.config import load_config
 from drakrun.lib.drakpdb import (
     DLL,
+    apivectors_dll_file_list,
     dll_file_list,
     fetch_pdb,
     make_pdb_profile,
+    optional_dll_file_list,
     pe_codeview_data,
     required_dll_file_list,
-    unrequired_dll_file_list,
 )
 from drakrun.lib.injector import Injector
 from drakrun.lib.install_info import InstallInfo
@@ -261,12 +262,18 @@ def create_vm_profiles(generate_apivectors_profile: bool):
     injector = Injector("vm-1", runtime_info, kernel_profile)
 
     # Ensure that all declared usermode profiles exist
-    # This is important when upgrade defines new entries in required_dll_file_list and unrequired_dll_file_list
+    # This is important when upgrade defines new entries in required_dll_file_list
     for profile in required_dll_file_list:
         create_rekall_profile(injector, profile, True)
 
+    for profile in optional_dll_file_list:
+        try:
+            create_rekall_profile(injector, profile)
+        except Exception:
+            log.exception("Unexpected exception from create_rekall_profile!")
+
     if generate_apivectors_profile:
-        for profile in unrequired_dll_file_list:
+        for profile in apivectors_dll_file_list:
             try:
                 create_rekall_profile(injector, profile)
             except Exception:

--- a/drakrun/drakrun/lib/drakpdb.py
+++ b/drakrun/drakrun/lib/drakpdb.py
@@ -15,7 +15,7 @@ DLL = NamedTuple("DLL", [("path", str), ("dest", str), ("arg", Optional[str])])
 
 
 # profile file list, without 'C:\' and with '/' instead of '\'
-# something is wrong if these DLLs fail
+# Profiles required by Drakvuf core
 required_dll_file_list = [
     DLL("Windows/System32/ntdll.dll", "amd64_ntdll_profile", "--json-ntdll"),
     DLL("Windows/SysWOW64/ntdll.dll", "wow64_ntdll_profile", "--json-wow"),
@@ -28,8 +28,8 @@ required_dll_file_list = [
     ),
 ]
 
-# profile file list, without 'C:\' and with '/' instead of '\'
-unrequired_dll_file_list = [
+# Profiles required by some Drakvuf plugins
+optional_dll_file_list = [
     DLL("Windows/System32/drivers/tcpip.sys", "amd64_tcpip_profile", "--json-tcpip"),
     DLL("Windows/System32/sspicli.dll", "amd64_sspicli_profile", "--json-sspicli"),
     DLL(
@@ -38,14 +38,7 @@ unrequired_dll_file_list = [
         "--json-kernelbase",
     ),
     DLL("Windows/System32/IPHLPAPI.DLL", "amd64_iphlpapi_profile", "--json-iphlpapi"),
-    DLL("Windows/SysWOW64/IPHLPAPI.DLL", "x86_iphlpapi_profile", None),
     DLL("Windows/System32/mpr.dll", "amd64_mpr_profile", "--json-mpr"),
-    DLL("Windows/SysWOW64/mpr.dll", "x86_mpr_profile", None),
-    DLL("Windows/System32/ole32.dll", "amd64_ole32_profile", None),
-    DLL("Windows/SysWOW64/ole32.dll", "x86_ole32_profile", None),
-    # wasn't able to find this file in our snapshot - should be investigated
-    # at some point
-    DLL("Windows/System32/combase.dll", "amd64_combase_profile", None),
     # .NET DLLs aren't present in winsxs and are 32-bit, use x86_prefix
     DLL(
         "Windows/Microsoft.NET/Framework/v4.0.30319/clr.dll",
@@ -57,6 +50,15 @@ unrequired_dll_file_list = [
         "x86_mscorwks_profile",
         "--json-mscorwks",
     ),
+]
+
+# Profiles used by Apivectors
+apivectors_dll_file_list = [
+    DLL("Windows/SysWOW64/IPHLPAPI.DLL", "x86_iphlpapi_profile", None),
+    DLL("Windows/SysWOW64/mpr.dll", "x86_mpr_profile", None),
+    DLL("Windows/System32/ole32.dll", "amd64_ole32_profile", None),
+    DLL("Windows/SysWOW64/ole32.dll", "x86_ole32_profile", None),
+    DLL("Windows/System32/combase.dll", "amd64_combase_profile", None),
     DLL(
         "Windows/winsxs/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a/GdiPlus.dll",
         "amd64_gdiplus_profile",
@@ -130,7 +132,9 @@ unrequired_dll_file_list = [
 ]
 
 
-dll_file_list = required_dll_file_list + unrequired_dll_file_list
+dll_file_list = (
+    required_dll_file_list + optional_dll_file_list + apivectors_dll_file_list
+)
 
 
 CV_RSDS_HEADER = "CV_RSDS" / Struct(


### PR DESCRIPTION
Some of them are actually "required" by plugins.