### PR TITLE
Basic support for injector TID pinning

### DIFF
--- a/drakrun/drakrun/lib/injector.py
+++ b/drakrun/drakrun/lib/injector.py
@@ -60,6 +60,11 @@ class Injector:
             hex(self.runtime_info.vmi_offsets.kpgd),
             "-m",
             method,
+            *(
+                ["-I", str(self.runtime_info.inject_tid)]
+                if self.runtime_info.inject_tid is not None
+                else []
+            ),
         ]
 
     def _get_cmdline_writefile(self, local: str, remote: str) -> List[str]:

--- a/drakrun/drakrun/lib/util.py
+++ b/drakrun/drakrun/lib/util.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 from dataclasses import dataclass, field
+from typing import Optional
 
 from dataclasses_json import config, dataclass_json
 
@@ -52,6 +53,7 @@ class VmiOffsets:
 class RuntimeInfo:
     vmi_offsets: VmiOffsets
     inject_pid: int
+    inject_tid: Optional[int] = None
 
     @staticmethod
     def load(file_path: str) -> "RuntimeInfo":


### PR DESCRIPTION
Related with https://github.com/CERT-Polska/drakvuf-sandbox/issues/933. Injector supports `-I` option that allows to pin injector to the specific TID.