### PR TITLE
drakshell: bootstrap agent to reduce injector usage

### DIFF
--- a/drakshell/.gitignore
+++ b/drakshell/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+guest/obj/*
+guest/drakshell

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -101,7 +101,7 @@ class Channel:
         self._sock.settimeout(timeout)
         resp = self._recv_control()
         if resp in [RespCode.RESP_STDOUT_DATA, RespCode.RESP_STDERR_DATA]:
-            block = self._recv_block()
+            block = self._recv_data()
             return resp, block
         elif resp in [RespCode.RESP_PROCESS_EXIT, RespCode.RESP_PROCESS_ERROR, RespCode.RESP_FATAL_ERROR]:
             code = self._recv_status_code()

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -1,0 +1,110 @@
+import struct
+import socket
+
+REQ_PING = 0x30
+REQ_UPLOAD = 0x31
+REQ_DOWNLOAD = 0x32
+REQ_EXIT = 0x33
+
+RESP_SUCCESS = 0x30
+RESP_FILE_OPENED = 0x31
+RESP_ERROR = 0x32
+
+
+class DrakshellClient:
+    MAX_BUFFER_SIZE = 4096
+
+    def __init__(self, unix_socket_path):
+        self.unix_socket_path = unix_socket_path
+        self._sock = None
+
+    def connect(self):
+        try:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.settimeout(3)
+            self._sock.connect(self.unix_socket_path)
+        except Exception:
+            self._sock = None
+            raise
+
+    def _send_req(self, req):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        msg = struct.pack("<B", req)
+        self._sock.send(msg)
+
+    def _recv_resp(self):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        msg = self._sock.recv(1)
+        if not msg:
+            raise RuntimeError('Socket has unexpectedly disconnected')
+        return msg[0]
+
+    def _recv_gle(self):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        msg = self._sock.recv(4)
+        if not msg:
+            raise RuntimeError('Socket has unexpectedly disconnected')
+        return struct.unpack("<I", msg)[0]
+
+    def _send_arg(self, arg):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        if len(arg) > self.MAX_BUFFER_SIZE:
+            raise ValueError("Message block too long")
+        len_msg = struct.pack("<H", len(arg))
+        self._sock.send(len_msg + arg)
+
+    def _recv_arg(self):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        len_msg = self._sock.recv(2)
+        if not len_msg:
+            raise RuntimeError('Socket has unexpectedly disconnected')
+        arg_len = struct.unpack("<I", len_msg)[0]
+        arg = b''
+        while arg_len > 0:
+            part = self._sock.recv(arg_len)
+            if not part:
+                raise RuntimeError('Socket has unexpectedly disconnected')
+            arg_len -= len(part)
+            arg += part
+        return arg
+
+    def ping(self):
+        self._send_req(REQ_PING)
+        resp = self._recv_resp()
+        if resp != RESP_SUCCESS:
+            raise RuntimeError(f'Unexpected response: {resp}')
+        return True
+
+    def upload_file(self, host_path, guest_path):
+        self._send_req(REQ_UPLOAD)
+        self._send_arg(guest_path.encode("utf-16le") + b"\0\0")
+        resp = self._recv_resp()
+        if resp == RESP_FILE_OPENED:
+            target_guest_path = self._recv_arg()
+        elif resp == RESP_ERROR:
+            gle = self._recv_gle()
+            raise RuntimeError(f"Can't open file for writing: {gle}")
+        else:
+            raise RuntimeError(f'Unexpected response: {resp}')
+
+        with open(host_path, "rb") as f:
+            while True:
+                block = f.read(self.MAX_BUFFER_SIZE)
+                self._send_arg(block)
+                if not block:
+                    break
+
+        resp = self._recv_resp()
+        if resp == RESP_SUCCESS:
+            return target_guest_path.decode("utf-16le")
+        elif resp == RESP_ERROR:
+            gle = self._recv_gle()
+            raise RuntimeError(f"Error during file read: {gle}")
+        else:
+            raise RuntimeError(f'Unexpected response: {resp}')
+

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -85,7 +85,7 @@ class Channel:
     def _recv_data(self):
         if self._sock is None:
             raise RuntimeError('Socket is not connected')
-        len_msg = self._sock.recv(2)
+        len_msg = self._recvn(2)
         if not len_msg:
             raise RuntimeError('Socket has unexpectedly disconnected')
         arg_len = struct.unpack("<H", len_msg)[0]

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -1,29 +1,35 @@
 import enum
 import struct
 import socket
-
-REQ_PING = 0x30
-REQ_INTERACTIVE_EXECUTE = 0x31
-REQ_EXECUTE_AND_FINISH = 0x32
-REQ_FINISH = 0x33
-REQ_BLOCK = 0x34
+import mslex
 
 
-class DrakshellRespCode(enum.IntEnum):
+class ReqCode(enum.IntEnum):
+    REQ_PING = 0x30
+    REQ_INTERACTIVE_EXECUTE = 0x31
+    REQ_NON_INTERACTIVE_EXECUTE = 0x32
+    REQ_EXECUTE_AND_FINISH = 0x33
+    REQ_FINISH = 0x34
+    REQ_DATA = 0x35
+    REQ_TERMINATE_PROCESS = 0x36
+
+
+class RespCode(enum.IntEnum):
     RESP_PONG = 0x30
     RESP_INTERACTIVE_EXECUTE_START = 0x31
-    RESP_EXECUTE_AND_FINISH_START = 0x32
-    RESP_FINISH_START = 0x33
-    RESP_STDOUT_BLOCK = 0x34
-    RESP_STDERR_BLOCK = 0x35
-    RESP_INTERACTIVE_EXECUTE_PROCESS_CREATED = 0x36
-    RESP_INTERACTIVE_EXECUTE_END = 0x37
-
+    RESP_NON_INTERACTIVE_EXECUTE_START = 0x32
+    RESP_EXECUTE_AND_FINISH_START = 0x33
+    RESP_FINISH_START = 0x34
+    RESP_STDOUT_DATA = 0x35
+    RESP_STDERR_DATA = 0x36
+    RESP_PROCESS_START = 0x37
+    RESP_PROCESS_EXIT = 0x38
     RESP_BAD_REQ = 0x40
     RESP_FATAL_ERROR = 0x41
+    RESP_PROCESS_ERROR = 0x42
 
 
-class DrakshellChannel:
+class Channel:
     MAX_BUFFER_SIZE = 4096
 
     def __init__(self, unix_socket_path):
@@ -33,16 +39,21 @@ class DrakshellChannel:
     def connect(self):
         try:
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self._sock.settimeout(3)
             self._sock.connect(self.unix_socket_path)
         except Exception:
             self._sock = None
             raise
 
+    def disconnect(self):
+        if self._sock is None:
+            raise RuntimeError('Socket is not connected')
+        self._sock.close()
+        self._sock = None
+
     def send_control(self, req):
         if self._sock is None:
             raise RuntimeError('Socket is not connected')
-        msg = struct.pack("<B", req)
+        msg = struct.pack("<B", int(req))
         self._sock.send(msg)
 
     def _recv_control(self):
@@ -51,7 +62,7 @@ class DrakshellChannel:
         msg = self._sock.recv(1)
         if not msg:
             raise RuntimeError('Socket has unexpectedly disconnected')
-        return DrakshellRespCode(msg[0])
+        return RespCode(msg[0])
 
     def _recv_status_code(self):
         if self._sock is None:
@@ -61,7 +72,7 @@ class DrakshellChannel:
             raise RuntimeError('Socket has unexpectedly disconnected')
         return struct.unpack("<I", msg)[0]
 
-    def _recv_block(self):
+    def _recv_data(self):
         if self._sock is None:
             raise RuntimeError('Socket is not connected')
         len_msg = self._sock.recv(2)
@@ -77,23 +88,101 @@ class DrakshellChannel:
             arg += part
         return arg
 
-    def send_block(self, arg):
+    def send_data(self, arg):
         if self._sock is None:
             raise RuntimeError('Socket is not connected')
         if len(arg) > self.MAX_BUFFER_SIZE:
             raise ValueError("Message block too long")
-        self.send_control(REQ_BLOCK)
+        self.send_control(ReqCode.REQ_DATA)
         len_msg = struct.pack("<H", len(arg))
         self._sock.send(len_msg + arg)
 
-    def recv_response(self):
+    def recv_response(self, timeout=15):
+        self._sock.settimeout(timeout)
         resp = self._recv_control()
-
-        if resp in [DrakshellRespCode.RESP_STDOUT_BLOCK, DrakshellRespCode.RESP_STDERR_BLOCK]:
+        if resp in [RespCode.RESP_STDOUT_DATA, RespCode.RESP_STDERR_DATA]:
             block = self._recv_block()
             return resp, block
-        elif resp in [DrakshellRespCode.RESP_FATAL_ERROR, DrakshellRespCode.RESP_INTERACTIVE_EXECUTE_END]:
+        elif resp in [RespCode.RESP_PROCESS_EXIT, RespCode.RESP_PROCESS_ERROR, RespCode.RESP_FATAL_ERROR]:
             code = self._recv_status_code()
             return resp, code
         return resp, None
 
+
+class Drakshell:
+    def __init__(self, unix_socket_path):
+        self.channel = Channel(unix_socket_path)
+
+    def connect(self):
+        self.channel.connect()
+
+    def disconnect(self):
+        self.channel.disconnect()
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+        return False
+
+    def run(self, args, capture_output=False, timeout=15):
+        self.channel.send_control(ReqCode.REQ_PING)
+        status, _ = self.channel.recv_response(timeout=3)
+        if status != RespCode.RESP_PONG:
+            raise RuntimeError(f"Drakshell ping failed: {status}")
+
+        cmdline = mslex.join(args, for_cmd=False).encode("utf-16le") + b"\0\0"
+
+        if len(cmdline) > 2048:
+            raise RuntimeError("Command line too long")
+
+        if capture_output:
+            self.channel.send_control(ReqCode.REQ_INTERACTIVE_EXECUTE)
+            expected_status = RespCode.RESP_INTERACTIVE_EXECUTE_START
+        else:
+            self.channel.send_control(ReqCode.REQ_NON_INTERACTIVE_EXECUTE)
+            expected_status = RespCode.RESP_NON_INTERACTIVE_EXECUTE_START
+
+        status, _ = self.channel.recv_response(timeout=3)
+        if status != expected_status:
+            raise RuntimeError(f"Fatal error: {status}")
+
+        self.channel.send_data(cmdline)
+
+        status, code = self.channel.recv_response(timeout=3)
+        if status == RespCode.RESP_PROCESS_START:
+            pass
+        elif status == RespCode.RESP_PROCESS_ERROR:
+            raise RuntimeError(f"Process startup failed: {code}")
+        else:
+            raise RuntimeError(f"Fatal error: {status}")
+
+        stdout = b''
+        stderr = b''
+        exit_code = 0
+
+        while True:
+            try:
+                status, data = self.channel.recv_response(timeout=timeout)
+            except:
+                self.channel.send_control(ReqCode.REQ_TERMINATE_PROCESS)
+                # Consume possible response
+                self.channel.recv_response()
+                raise
+            if status == RespCode.RESP_STDOUT_DATA:
+                stdout += data
+            elif status == RespCode.RESP_STDOUT_DATA:
+                stderr += data
+            elif status == RespCode.RESP_PROCESS_EXIT:
+                exit_code = data
+                break
+            else:
+                raise RuntimeError(f"Fatal error: {status}")
+
+        return {
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+        }

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -63,7 +63,7 @@ class DrakshellClient:
         len_msg = self._sock.recv(2)
         if not len_msg:
             raise RuntimeError('Socket has unexpectedly disconnected')
-        arg_len = struct.unpack("<I", len_msg)[0]
+        arg_len = struct.unpack("<H", len_msg)[0]
         arg = b''
         while arg_len > 0:
             part = self._sock.recv(arg_len)

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -23,7 +23,7 @@ class DrakshellRespCode(enum.IntEnum):
     RESP_FATAL_ERROR = 0x41
 
 
-class DrakshellClient:
+class DrakshellChannel:
     MAX_BUFFER_SIZE = 4096
 
     def __init__(self, unix_socket_path):
@@ -96,3 +96,4 @@ class DrakshellClient:
             code = self._recv_status_code()
             return resp, code
         return resp, None
+

--- a/drakshell/drakshell_client.py
+++ b/drakshell/drakshell_client.py
@@ -64,10 +64,20 @@ class Channel:
             raise RuntimeError('Socket has unexpectedly disconnected')
         return RespCode(msg[0])
 
+    def _recvn(self, size):
+        data = b''
+        while size > 0:
+            part = self._sock.recv(size)
+            if not part:
+                raise RuntimeError('Socket has unexpectedly disconnected')
+            size -= len(part)
+            data += part
+        return data
+
     def _recv_status_code(self):
         if self._sock is None:
             raise RuntimeError('Socket is not connected')
-        msg = self._sock.recv(4)
+        msg = self._recvn(4)
         if not msg:
             raise RuntimeError('Socket has unexpectedly disconnected')
         return struct.unpack("<I", msg)[0]
@@ -79,14 +89,7 @@ class Channel:
         if not len_msg:
             raise RuntimeError('Socket has unexpectedly disconnected')
         arg_len = struct.unpack("<H", len_msg)[0]
-        arg = b''
-        while arg_len > 0:
-            part = self._sock.recv(arg_len)
-            if not part:
-                raise RuntimeError('Socket has unexpectedly disconnected')
-            arg_len -= len(part)
-            arg += part
-        return arg
+        return self._recvn(arg_len)
 
     def send_data(self, arg):
         if self._sock is None:

--- a/drakshell/guest/Makefile
+++ b/drakshell/guest/Makefile
@@ -6,7 +6,7 @@ ODIR=obj
 _DEPS = nt_loader.h
 DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
 
-_OBJ = nt_loader.o drakshell.o
+_OBJ = nt_loader.o drakshell.o thread_start.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 drakshell: $(ODIR)/drakshell.elf
@@ -14,6 +14,9 @@ drakshell: $(ODIR)/drakshell.elf
 
 $(ODIR)/%.o: %.c $(DEPS)
 	gcc -c -o $@ $< $(CFLAGS)
+
+$(ODIR)/%.o: %.S $(DEPS)
+	gcc -c -o $@ $<
 
 $(ODIR)/drakshell.elf: $(OBJ)
 	gcc $(LFLAGS) -o $@ $^ $(CFLAGS)

--- a/drakshell/guest/Makefile
+++ b/drakshell/guest/Makefile
@@ -1,0 +1,24 @@
+IDIR =./include
+CFLAGS=-I$(IDIR) -fPIE -nostdlib -ffreestanding -masm=intel -march=haswell -fshort-wchar -O2
+LFLAGS=-T linker.ld
+ODIR=obj
+
+_DEPS = nt_loader.h
+DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
+
+_OBJ = nt_loader.o drakshell.o
+OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
+
+drakshell: $(ODIR)/drakshell.elf
+	objcopy -O binary -j.text -j.bss --set-section-flags .bss=alloc,load,contents $^ drakshell
+
+$(ODIR)/%.o: %.c $(DEPS)
+	gcc -c -o $@ $< $(CFLAGS)
+
+$(ODIR)/drakshell.elf: $(OBJ)
+	gcc $(LFLAGS) -o $@ $^ $(CFLAGS)
+
+clean:
+	rm -f drakshell $(ODIR)/*.o $(ODIR)/*.elf *~ core $(INCDIR)/*~
+
+.PHONY: clean

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -258,7 +258,7 @@ void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshel
     }
 
     dcb.BaudRate = 115200;
-    dcb.fParity = false;
+    dcb.fParity = true;
 
     if(!SetCommState(hComm, &dcb))
     {

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -33,13 +33,13 @@ static bool read(HANDLE hComm, LPBYTE buffer, LPDWORD size, DWORD maxSize) {
         if(GetLastError() != ERROR_IO_PENDING) {
             return false;
         }
-        result = WaitForSingleObject(overlapped.hEvent, INFINITE)
+        result = WaitForSingleObject(overlapped.hEvent, INFINITE);
         if(result) {
             // Not a WAIT_OBJECT_0
             return false;
         }
     }
-    if(!GetOverlappedResult(hComm, &overlapped, size, FALSE)) {
+    if(!GetOverlappedResult(hComm, &overlapped, size, false)) {
         return false;
     }
     return true;
@@ -54,13 +54,13 @@ static bool write(HANDLE hComm, LPBYTE buffer, LPDWORD size, DWORD maxSize) {
         if(GetLastError() != ERROR_IO_PENDING) {
             return false;
         }
-        result = WaitForSingleObject(overlapped.hEvent, INFINITE)
+        result = WaitForSingleObject(overlapped.hEvent, INFINITE);
         if(result) {
             // Not a WAIT_OBJECT_0
             return false;
         }
     }
-    if(!GetOverlappedResult(hComm, &overlapped, size, FALSE)) {
+    if(!GetOverlappedResult(hComm, &overlapped, size, false)) {
         return false;
     }
     return true;

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -1,0 +1,335 @@
+// gcc  headless.c
+// objcopy -O binary --only-section=.text a.out out_objcopy_onlysection
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "nt_loader.h"
+
+#define REQ_PING 0x30
+#define REQ_UPLOAD 0x31
+#define REQ_DOWNLOAD 0x32
+#define REQ_EXIT 0x33
+
+#define RESP_SUCCESS 0x30
+#define RESP_FILE_OPENED 0x31
+#define RESP_ERROR 0x32
+
+static bool recv(HANDLE hComm, LPBYTE buffer, DWORD size) {
+    DWORD bytesRead = 0;
+
+    while(size > 0) {
+        if(!ReadFile(hComm, buffer, size, &bytesRead, NULL)) {
+            return false;
+        }
+        if(!bytesRead) {
+            return false;
+        }
+        size -= bytesRead;
+        buffer += bytesRead;
+    }
+    return true;
+}
+
+static bool send(HANDLE hComm, LPBYTE buffer, DWORD size) {
+    DWORD bytesWritten = 0;
+
+    while(size > 0) {
+        if(!WriteFile(hComm, buffer, size, &bytesWritten, NULL)) {
+            return false;
+        }
+        if(!bytesWritten) {
+            return false;
+        }
+        size -= bytesWritten;
+        buffer += bytesWritten;
+    }
+    return true;
+}
+
+static bool recv_req(HANDLE hComm, LPBYTE req) {
+    return recv(hComm, req, sizeof(*req));
+}
+
+static bool send_resp(HANDLE hComm, BYTE resp) {
+    return send(hComm, &resp, sizeof(resp));
+}
+
+static bool send_error(HANDLE hComm) {
+    DWORD gle = GetLastError();
+    BYTE resp = RESP_ERROR;
+    if(!send(hComm, &resp, sizeof(resp)))
+        return false;
+    return send(hComm, (LPBYTE)&gle, sizeof(gle));
+}
+
+static bool recv_arg(HANDLE hComm, LPBYTE bufferToRecv, LPWORD argSize, WORD argMaxSize) {
+    if(!recv(hComm, (LPBYTE)argSize, sizeof(*argSize))) {
+        return false;
+    }
+    if(*argSize > argMaxSize) {
+        return false;
+    }
+    return recv(hComm, bufferToRecv, *argSize);
+}
+
+static bool send_arg(HANDLE hComm, LPBYTE bufferToSend, WORD argSize) {
+    if(!send(hComm, (LPBYTE)&argSize, sizeof(argSize))) {
+        return false;
+    }
+    if(!argSize)
+        return true;
+    return send(hComm, bufferToSend, argSize);
+}
+
+static bool req_ping(HANDLE hComm) {
+    return send_resp(hComm, RESP_SUCCESS);
+}
+
+static bool req_upload_file(HANDLE hComm)
+{
+    union {
+        struct {
+            wchar_t fileName[512];
+            wchar_t targetFileName[512];
+        };
+        BYTE buffer[4096];
+    } buffers;
+    WORD readBytes = 0;
+    // Receive file name
+    if(!recv_arg(hComm, (LPBYTE)buffers.fileName, &readBytes, sizeof(buffers.fileName) - sizeof(wchar_t))) {
+        return false;
+    }
+    // Ensure terminator at the end
+    buffers.fileName[readBytes] = 0;
+    // Expand into target file name
+    DWORD maxTargetSize = (sizeof(buffers.targetFileName) / sizeof(wchar_t));
+    DWORD targetSize = ExpandEnvironmentStringsW(buffers.fileName, buffers.targetFileName, maxTargetSize);
+    if(!targetSize || targetSize > maxTargetSize) {
+        send_error(hComm);
+        return true;
+    }
+    // Try to open file for writing
+    HANDLE hFile = CreateFileW(
+        buffers.targetFileName,
+        GENERIC_WRITE,
+        0,
+        NULL,
+        CREATE_NEW,
+        0,
+        NULL
+    );
+    if(hFile == INVALID_HANDLE_VALUE) {
+        send_error(hComm);
+        return true;
+    }
+    // If everything is OK so far, let client continue its upload
+    if(!send_resp(hComm, RESP_FILE_OPENED)) {
+        CloseHandle(hFile);
+        return false;
+    }
+    if(!send_arg(hComm, (LPBYTE)buffers.targetFileName, targetSize * sizeof(wchar_t))) {
+        CloseHandle(hFile);
+        return false;
+    }
+
+    DWORD bytesWritten;
+
+    while(true) {
+        if(!recv_arg(hComm, buffers.buffer, &readBytes, sizeof(buffers.buffer))) {
+            CloseHandle(hFile);
+            return false;
+        }
+        if(readBytes == 0) {
+            break;
+        }
+        if(!WriteFile(hFile, buffers.buffer, readBytes, &bytesWritten, NULL)) {
+            send_error(hComm);
+            CloseHandle(hFile);
+            return true;
+        }
+    }
+    send_resp(hComm, RESP_SUCCESS);
+    CloseHandle(hFile);
+    return true;
+}
+
+static bool req_download_file(HANDLE hComm)
+{
+    union {
+        struct {
+            wchar_t fileName[512];
+            wchar_t targetFileName[512];
+        };
+        BYTE buffer[4096];
+    } buffers;
+    WORD readBytes = 0;
+    // Receive file name
+    if(!recv_arg(hComm, (LPBYTE)buffers.fileName, &readBytes, sizeof(buffers.fileName) - sizeof(wchar_t))) {
+        return false;
+    }
+    // Ensure terminator at the end
+    buffers.fileName[readBytes] = 0;
+    // Expand into target file name
+    DWORD maxTargetSize = (sizeof(buffers.targetFileName) / sizeof(wchar_t));
+    DWORD targetSize = ExpandEnvironmentStringsW(buffers.fileName, buffers.targetFileName, maxTargetSize);
+    if(!targetSize || targetSize > maxTargetSize) {
+        send_error(hComm);
+        return true;
+    }
+    // Try to open file for writing
+    HANDLE hFile = CreateFileW(
+        buffers.targetFileName,
+        GENERIC_READ,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        0,
+        NULL
+    );
+    if(hFile == INVALID_HANDLE_VALUE) {
+        send_error(hComm);
+        return true;
+    }
+    // If everything is OK so far, let client continue its upload
+    if(!send_resp(hComm, RESP_FILE_OPENED)) {
+        CloseHandle(hFile);
+        return false;
+    }
+    if(!send_arg(hComm, (LPBYTE)buffers.targetFileName, targetSize * sizeof(wchar_t))) {
+        CloseHandle(hFile);
+        return false;
+    }
+
+    DWORD readBytesFromFile;
+
+    while(true) {
+        if(!ReadFile(hFile, buffers.buffer, sizeof(buffers.buffer), &readBytesFromFile, NULL)) {
+            send_arg(hComm, NULL, 0); // send EOF
+            send_error(hComm); // then reading error
+            CloseHandle(hFile);
+            return true;
+        }
+        if(!send_arg(hComm, buffers.buffer, readBytesFromFile)) {
+            CloseHandle(hFile);
+            return false;
+        }
+        if(readBytes == 0) {
+            // EOF has been sent, we can break the loop
+            break;
+        }
+    }
+    send_resp(hComm, RESP_SUCCESS);
+    CloseHandle(hFile);
+    return true;
+}
+
+static void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
+    if(!load_winapi()) {
+        // Failed to load some WinAPI functions
+        return;
+    }
+
+    Sleep(500); // Some sleep to let injector finish his job
+
+    OutputDebugStringW(L"Hello from drakshell");
+
+    HANDLE hComm = CreateFileW(
+        L"\\\\.\\COM1",
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        0,
+        NULL
+    );
+    if(hComm == INVALID_HANDLE_VALUE)
+    {
+        OutputDebugStringW(L"Failed to connect to COM1");
+        return;
+    }
+
+    OutputDebugStringW(L"I'm connected");
+
+    while(true) {
+        BYTE command = 0;
+
+        if(!recv(hComm, &command, 1)) {
+            break;
+        }
+
+        if(command == REQ_PING) {
+            if(!req_ping(hComm))
+                break;
+        }
+        else if(command == REQ_UPLOAD) {
+            if(!req_upload_file(hComm))
+                break;
+        }
+        else if(command == REQ_DOWNLOAD) {
+            if(!req_download_file(hComm))
+                break;
+        }
+    }
+    OutputDebugStringW(L"Bye");
+    CloseHandle(hComm);
+}
+
+static DWORD WINAPI __attribute__((naked)) thread_start() {
+    #if defined(__x86_64__)
+    asm("push rcx");
+    #endif
+    #if defined(__i386__)
+    asm("push ecx");
+    #endif
+
+    drakshell_main();
+
+    // This one is going to deallocate memory occupied by shellcode
+    // and finish the thread to cover up all traces of drakshell
+    // in explorer.exe
+    //
+    // We're going to jump to the VirtualFree and it is going to
+    // return to the ExitThread for us.
+    #if defined(__x86_64__)
+    asm("pop rcx\n"
+        "and rcx, -4096\n"
+        "xor rdx, rdx\n"
+        "mov r8, 0x8000\n"
+        "jmp %0"
+        : : "r" (pVirtualFree));
+    #endif
+    #if defined(__i386__)
+    // TODO: Support 32-bit host process as well?
+    asm("pop ecx\n"
+        "xor eax, eax\n"
+        "ret\n")
+    #endif
+}
+
+// Tell the compiler incoming stack alignment is not RSP%16==8 or ESP%16==12
+__attribute__((force_align_arg_pointer))
+__attribute__((section(".startup")))
+void _start() {
+    // Escape from hijacked thread to the dedicated thread ASAP
+    // This will cause injector to recover the original thread
+    // and make possible to do any long-term actions without interfering
+    // with explorer.exe operations
+
+    // Universal get_pc_thunk for further cleanup
+    // _start will be for sure somewhere on the first page
+    // of injected code allocation
+    volatile void* base_ptr;
+    asm("call _next\n\t"
+        "_next: pop %0": "=r"(base_ptr));
+
+    PCreateThread pCreateThread = get_func_from_peb(L"kernel32.dll", "CreateThread");
+    (*pCreateThread)(
+        NULL, // lpThreadAttributes
+        0,    // dwStackSize
+        thread_start,
+        (void*)base_ptr, // lpParameter
+        0,    // dwCreationFlags
+        NULL // lpThreadId
+    );
+}

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -295,6 +295,7 @@ static bool interactive_execute(HANDLE hComm) {
         HANDLE waitable_handles[4] = {
             hProcess, opStdin.hEvent, opStdout.hEvent, opStderr.hEvent
         };
+        OutputDebugStringW(L"interactive_execute: waiting for next event");
         DWORD status = WaitForMultipleObjects(
             4, waitable_handles, false, 0xFFFFFFFF
         );
@@ -353,7 +354,6 @@ static bool interactive_execute(HANDLE hComm) {
                     OutputDebugStringW(L"interactive_execute: stdin write failed");
                     break;
                 }
-                OutputDebugStringW(L"interactive_execute: stdin handled");
             }
             if(!ReadFile(hComm, &control, 1, NULL, &opStdin)) {
                 if(GetLastError() == ERROR_IO_PENDING) {
@@ -373,6 +373,7 @@ static bool interactive_execute(HANDLE hComm) {
                 OutputDebugStringW(L"interactive_execute: got stdin immediately");
                 stdinPending = true;
             }
+            OutputDebugStringW(L"interactive_execute: stdin handled");
         }
         else if (status == 2) {
             OutputDebugStringW(L"interactive_execute: stdout signalled");

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -225,6 +225,8 @@ static bool req_download_file(HANDLE hComm)
 }
 
 void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
+    DCB dcb = { .DCBlength = sizeof(DCB) };
+
     if(!load_winapi()) {
         // Failed to load some WinAPI functions
         return;
@@ -246,6 +248,21 @@ void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshel
     if(hComm == INVALID_HANDLE_VALUE)
     {
         OutputDebugStringW(L"Failed to connect to COM1");
+        return;
+    }
+
+    if(!GetCommState(hComm, &dcb))
+    {
+        OutputDebugStringW(L"Failed to get mode of COM1");
+        return;
+    }
+
+    dcb.BaudRate = 115200;
+    dcb.fParity = false;
+
+    if(!SetCommState(hComm, &dcb))
+    {
+        OutputDebugStringW(L"Failed to set mode of COM1");
         return;
     }
 

--- a/drakshell/guest/drakshell.c
+++ b/drakshell/guest/drakshell.c
@@ -224,7 +224,7 @@ static bool req_download_file(HANDLE hComm)
     return true;
 }
 
-static void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
+void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
     if(!load_winapi()) {
         // Failed to load some WinAPI functions
         return;
@@ -275,37 +275,7 @@ static void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) d
     CloseHandle(hComm);
 }
 
-static DWORD WINAPI __attribute__((naked)) thread_start() {
-    #if defined(__x86_64__)
-    asm("push rcx");
-    #endif
-    #if defined(__i386__)
-    asm("push ecx");
-    #endif
-
-    drakshell_main();
-
-    // This one is going to deallocate memory occupied by shellcode
-    // and finish the thread to cover up all traces of drakshell
-    // in explorer.exe
-    //
-    // We're going to jump to the VirtualFree and it is going to
-    // return to the ExitThread for us.
-    #if defined(__x86_64__)
-    asm("pop rcx\n"
-        "and rcx, -4096\n"
-        "xor rdx, rdx\n"
-        "mov r8, 0x8000\n"
-        "jmp %0"
-        : : "r" (pVirtualFree));
-    #endif
-    #if defined(__i386__)
-    // TODO: Support 32-bit host process as well?
-    asm("pop ecx\n"
-        "xor eax, eax\n"
-        "ret\n")
-    #endif
-}
+extern void thread_start();
 
 // Tell the compiler incoming stack alignment is not RSP%16==8 or ESP%16==12
 __attribute__((force_align_arg_pointer))

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if __SIZEOF_WCHAR_T__ != 2
+#error "wchar_t is not two-byte, please compile with -fshort-wchar"
+#endif
+
+#define GENERIC_WRITE 0x40000000
+#define GENERIC_READ  0x80000000
+#define OPEN_EXISTING 3
+#define CREATE_NEW 1
+#define INVALID_HANDLE_VALUE ((void*)(long long)-1)
+
+typedef uint8_t BYTE;
+typedef uint16_t WORD;
+typedef uint32_t DWORD;
+typedef uint64_t QWORD;
+
+typedef uint8_t * PBYTE, * LPBYTE;
+typedef uint16_t * PWORD, * LPWORD;
+typedef uint32_t * PDWORD, * LPDWORD;
+typedef uint64_t * PQWORD, * LPQWORD;
+
+typedef long LONG;
+typedef unsigned long ULONG;
+typedef int INT;
+typedef unsigned int UINT;
+typedef short SHORT;
+typedef unsigned short USHORT;
+typedef char CHAR;
+typedef unsigned char UCHAR;
+
+typedef void* HANDLE;
+typedef void* LPVOID;
+typedef unsigned long SIZE_T;
+typedef const char* LPCSTR;
+typedef const wchar_t* LPCWSTR;
+typedef char* LPSTR;
+typedef wchar_t* LPWSTR;
+typedef bool BOOL;
+
+#define WINAPI __attribute__((ms_abi))
+
+typedef int (WINAPI* PCreateThread)(
+    LPVOID lpThreadAttributes,
+    SIZE_T dwStackSize,
+    LPVOID lpStartAddress,
+    LPVOID lpParameter,
+    DWORD dwCreationFlags,
+    LPDWORD lpThreadId
+);
+extern PCreateThread pCreateThread;
+#define CreateThread (*pCreateThread)
+
+typedef HANDLE (WINAPI* PLoadLibraryW)(LPCWSTR lpLibFileName);
+extern PLoadLibraryW pLoadLibraryW;
+#define LoadLibraryW (*pLoadLibraryW)
+
+typedef HANDLE (WINAPI* PGetProcAddress)(HANDLE hModule, LPCSTR lpProcName);
+extern PGetProcAddress pGetProcAddress;
+#define GetProcAddress (*pGetProcAddress)
+
+typedef int (WINAPI* PMessageBoxA)(HANDLE, LPCSTR, LPCSTR, UINT);
+extern PMessageBoxA pMessageBoxA;
+#define MessageBoxA (*pMessageBoxA)
+
+typedef DWORD (WINAPI* PExpandEnvironmentStringsW)(LPCWSTR lpSrc, LPWSTR lpDst, DWORD nSize);
+extern PExpandEnvironmentStringsW pExpandEnvironmentStringsW;
+#define ExpandEnvironmentStringsW (*pExpandEnvironmentStringsW)
+
+typedef void (WINAPI* POutputDebugStringW)(LPCWSTR lpOutputString);
+extern POutputDebugStringW pOutputDebugStringW;
+#define OutputDebugStringW (*pOutputDebugStringW)
+
+typedef bool (WINAPI* PCloseHandle)(HANDLE hObject);
+extern PCloseHandle pCloseHandle;
+#define CloseHandle (*pCloseHandle)
+
+typedef HANDLE (WINAPI* PCreateFileW)(
+    LPCWSTR lpFileName,
+    DWORD dwDesiredAccess,
+    DWORD dwShareMode,
+    LPVOID lpSecurityAttributes,
+    DWORD dwCreationDisposition,
+    DWORD dwFlagsAndAttributes,
+    HANDLE hTemplateFile
+);
+extern PCreateFileW pCreateFileW;
+#define CreateFileW (*pCreateFileW)
+
+typedef bool (WINAPI* PReadFile)(
+    HANDLE hFile,
+    LPVOID lpBuffer,
+    DWORD nNumberOfBytesToRead,
+    LPDWORD lpNumberOfBytesRead,
+    LPVOID lpOverlapped
+);
+extern PReadFile pReadFile;
+#define ReadFile (*pReadFile)
+
+typedef bool (WINAPI* PWriteFile)(
+    HANDLE hFile,
+    LPVOID lpBuffer,
+    DWORD nNumberOfBytesToWrite,
+    LPDWORD lpNumberOfBytesWritten,
+    LPVOID lpOverlapped
+);
+extern PWriteFile pWriteFile;
+#define WriteFile (*pWriteFile)
+
+typedef bool (WINAPI* PCreateProcessW)(
+    LPCWSTR lpApplicationName,
+    LPWSTR lpCommandLine,
+    LPVOID lpProcessAttributes,
+    LPVOID lpThreadAttributes,
+    BOOL bInheritHandles,
+    DWORD dwCreationFlags,
+    LPVOID lpEnvironment,
+    LPCWSTR lpCurrentDirectory,
+    LPVOID lpStartupInfo,
+    LPVOID lpProcessInformation
+);
+extern PCreateProcessW pCreateProcessW;
+#define CreateProcessW (*pCreateProcessW)
+
+typedef void (WINAPI* PExitThread)(
+    DWORD dwExitCode
+);
+extern PExitThread pExitThread;
+#define ExitThread (*pExitThread)
+
+typedef void (WINAPI* PSleep)(
+    DWORD dwMilliseconds
+);
+extern PSleep pSleep;
+#define Sleep (*pSleep)
+
+typedef void (WINAPI* PVirtualFree)(
+    LPVOID lpAddress,
+    SIZE_T dwSize,
+    DWORD  dwFreeType
+);
+extern PVirtualFree pVirtualFree;
+
+typedef DWORD (WINAPI* PGetLastError)();
+extern PGetLastError pGetLastError;
+#define GetLastError (*pGetLastError)
+
+extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
+extern bool load_winapi();

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -42,6 +42,37 @@ typedef char* LPSTR;
 typedef wchar_t* LPWSTR;
 typedef bool BOOL;
 
+typedef struct _DCB {
+    DWORD DCBlength;
+    DWORD BaudRate;
+    DWORD fBinary : 1;
+    DWORD fParity : 1;
+    DWORD fOutxCtsFlow : 1;
+    DWORD fOutxDsrFlow : 1;
+    DWORD fDtrControl : 2;
+    DWORD fDsrSensitivity : 1;
+    DWORD fTXContinueOnXoff : 1;
+    DWORD fOutX : 1;
+    DWORD fInX : 1;
+    DWORD fErrorChar : 1;
+    DWORD fNull : 1;
+    DWORD fRtsControl : 2;
+    DWORD fAbortOnError : 1;
+    DWORD fDummy2 : 17;
+    WORD  wReserved;
+    WORD  XonLim;
+    WORD  XoffLim;
+    BYTE  ByteSize;
+    BYTE  Parity;
+    BYTE  StopBits;
+    char  XonChar;
+    char  XoffChar;
+    char  ErrorChar;
+    char  EofChar;
+    char  EvtChar;
+    WORD  wReserved1;
+} DCB, *LPDCB;
+
 #define WINAPI __attribute__((ms_abi))
 
 typedef int (WINAPI* PCreateThread)(
@@ -148,6 +179,20 @@ extern PVirtualFree pVirtualFree;
 typedef DWORD (WINAPI* PGetLastError)();
 extern PGetLastError pGetLastError;
 #define GetLastError (*pGetLastError)
+
+typedef BOOL (WINAPI* PGetCommState)(
+    HANDLE hFile,
+    LPDCB  lpDCB
+);
+extern PGetCommState pGetCommState;
+#define GetCommState (*pGetCommState)
+
+typedef BOOL (WINAPI* PSetCommState)(
+    HANDLE hFile,
+    LPDCB  lpDCB
+);
+extern PSetCommState pSetCommState;
+#define SetCommState (*pSetCommState)
 
 extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
 extern bool load_winapi();

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -15,7 +15,8 @@
 #define INVALID_HANDLE_VALUE ((void*)(long long)-1)
 #define HANDLE_FLAG_INHERIT 1
 #define STARTF_USESTDHANDLES 0x00000100
-
+#define ERROR_IO_PENDING 0x000003e5
+#define ERROR_BROKEN_PIPE 0x0000006d
 
 typedef uint8_t BYTE;
 typedef uint16_t WORD;
@@ -280,6 +281,35 @@ typedef HANDLE (WINAPI* PCreateEvent)(
 );
 extern PCreateEvent pCreateEvent;
 #define CreateEvent (*pCreateEvent)
+
+typedef BOOL (WINAPI* PGetOverlappedResult)(
+    HANDLE hFile,
+    LPOVERLAPPED lpOverlapped,
+    LPDWORD lpNumberOfBytesTransferred,
+    BOOL bWait
+);
+extern PGetOverlappedResult pGetOverlappedResult;
+#define GetOverlappedResult (*pGetOverlappedResult)
+
+typedef BOOL (WINAPI* PCancelIo)(
+    HANDLE hFile
+);
+extern PCancelIo pCancelIo;
+#define CancelIo (*pCancelIo)
+
+typedef BOOL (WINAPI* PGetExitCodeProcess)(
+    HANDLE hProcess,
+    LPDWORD lpExitCode
+);
+extern PGetExitCodeProcess pGetExitCodeProcess;
+#define GetExitCodeProcess (*pGetExitCodeProcess)
+
+typedef BOOL (WINAPI* PTerminateProcess)(
+    HANDLE hProcess,
+    UINT uExitCode
+);
+extern PTerminateProcess pTerminateProcess;
+#define TerminateProcess (*pTerminateProcess)
 
 extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
 extern bool load_winapi();

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -17,6 +17,11 @@
 #define STARTF_USESTDHANDLES 0x00000100
 #define ERROR_IO_PENDING 0x000003e5
 #define ERROR_BROKEN_PIPE 0x0000006d
+#define PIPE_ACCESS_DUPLEX 0x00000003
+#define PIPE_ACCESS_OUTBOUND 0x00000002
+#define PIPE_ACCESS_INBOUND 0x00000001
+#define FILE_FLAG_OVERLAPPED 0x40000000
+#define FILE_FLAG_FIRST_PIPE_INSTANCE 0x00080000
 
 typedef uint8_t BYTE;
 typedef uint16_t WORD;
@@ -310,6 +315,19 @@ typedef BOOL (WINAPI* PTerminateProcess)(
 );
 extern PTerminateProcess pTerminateProcess;
 #define TerminateProcess (*pTerminateProcess)
+
+typedef HANDLE (WINAPI* PCreateNamedPipeW)(
+    LPCWSTR lpName,
+    DWORD dwOpenMode,
+    DWORD dwPipeMode,
+    DWORD nMaxInstances,
+    DWORD nOutBufferSize,
+    DWORD nInBufferSize,
+    DWORD nDefaultTimeOut,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes
+);
+extern PCreateNamedPipeW pCreateNamedPipeW;
+#define CreateNamedPipe (*pCreateNamedPipeW)
 
 extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
 extern bool load_winapi();

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -337,5 +337,11 @@ typedef DWORD (WINAPI* PWaitForSingleObject)(
 extern PWaitForSingleObject pWaitForSingleObject;
 #define WaitForSingleObject (*pWaitForSingleObject)
 
+typedef void (WINAPI* PSetLastError)(
+    DWORD dwErrCode
+);
+extern PSetLastError pSetLastError;
+#define SetLastError (*pSetLastError)
+
 extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
 extern bool load_winapi();

--- a/drakshell/guest/include/nt_loader.h
+++ b/drakshell/guest/include/nt_loader.h
@@ -22,6 +22,7 @@
 #define PIPE_ACCESS_INBOUND 0x00000001
 #define FILE_FLAG_OVERLAPPED 0x40000000
 #define FILE_FLAG_FIRST_PIPE_INSTANCE 0x00080000
+#define INFINITE 0xffffffff
 
 typedef uint8_t BYTE;
 typedef uint16_t WORD;
@@ -328,6 +329,13 @@ typedef HANDLE (WINAPI* PCreateNamedPipeW)(
 );
 extern PCreateNamedPipeW pCreateNamedPipeW;
 #define CreateNamedPipe (*pCreateNamedPipeW)
+
+typedef DWORD (WINAPI* PWaitForSingleObject)(
+    HANDLE hHandle,
+    DWORD  dwMilliseconds
+);
+extern PWaitForSingleObject pWaitForSingleObject;
+#define WaitForSingleObject (*pWaitForSingleObject)
 
 extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
 extern bool load_winapi();

--- a/drakshell/guest/linker.ld
+++ b/drakshell/guest/linker.ld
@@ -1,0 +1,37 @@
+ENTRY(_start)
+
+PHDRS {
+    text PT_LOAD FLAGS(7);   /* R-X */
+}
+SECTIONS
+{
+    .text : SUBALIGN(16)
+    {
+        *(.startup)
+        *(.text)
+        *(.text.*)
+        *(.data)
+        *(.data.*)
+        *(.rodata)
+        *(.rodata.*)
+    } :text
+
+    .bss : SUBALIGN(16)
+    {
+        bss_start = .;
+        *(.bss)
+        *(.bss.*)
+        bss_end = .;
+    }
+
+    /DISCARD/ : {
+        *(.comment)
+        *(.dynsym)
+        *(.dynstr)
+        *(.gnu.hash)
+        *(.hash)
+        *(.eh_frame_hdr)
+        *(.eh_frame)
+        *(.dynamic)
+    }
+}

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -218,6 +218,8 @@ PExitThread pExitThread;
 PSleep pSleep;
 PVirtualFree pVirtualFree;
 PGetLastError pGetLastError;
+PGetCommState pGetCommState;
+PSetCommState pSetCommState;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -244,6 +246,8 @@ bool load_winapi() {
     pSleep = GetProcAddress(hKernel32, "Sleep");
     pVirtualFree = GetProcAddress(hKernel32, "VirtualFree");
     pGetLastError = GetProcAddress(hKernel32, "GetLastError");
+    pGetCommState = GetProcAddress(hKernel32, "GetCommState");
+    pSetCommState = GetProcAddress(hKernel32, "SetCommState");
 
     return true;
 }

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -220,6 +220,10 @@ PVirtualFree pVirtualFree;
 PGetLastError pGetLastError;
 PGetCommState pGetCommState;
 PSetCommState pSetCommState;
+PCreatePipe pCreatePipe;
+PSetHandleInformation pSetHandleInformation;
+PWaitForMultipleObjects pWaitForMultipleObjects;
+PCreateEvent pCreateEvent;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -248,6 +252,10 @@ bool load_winapi() {
     pGetLastError = GetProcAddress(hKernel32, "GetLastError");
     pGetCommState = GetProcAddress(hKernel32, "GetCommState");
     pSetCommState = GetProcAddress(hKernel32, "SetCommState");
+    pCreatePipe = GetProcAddress(hKernel32, "CreatePipe");
+    pSetHandleInformation = GetProcAddress(hKernel32, "SetHandleInformation");
+    pWaitForMultipleObjects = GetProcAddress(hKernel32, "WaitForMultipleObjects");
+    pCreateEvent = GetProcAddress(hKernel32, "CreateEventA");
 
     return true;
 }

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -1,0 +1,249 @@
+#include "nt_loader.h"
+
+typedef struct _LIST_ENTRY {
+    struct _LIST_ENTRY *Flink;
+    struct _LIST_ENTRY *Blink;
+} LIST_ENTRY, *PLIST_ENTRY;
+
+typedef struct _PEB_LDR_DATA {
+    uint8_t Reserved1[8];
+    void* Reserved2[2];
+    LIST_ENTRY InLoadOrderModuleList;
+    LIST_ENTRY InMemoryOrderModuleList;
+    LIST_ENTRY InInitOrderModuleList;
+} PEB_LDR_DATA, *PPEB_LDR_DATA;
+
+typedef struct _PEB {
+    uint8_t Reserved1[2];
+    uint8_t BeingDebugged;
+    uint8_t Reserved2[1];
+    void* Reserved3[2];
+    PPEB_LDR_DATA Ldr;
+} PEB, *PPEB;
+
+typedef struct _UNICODE_STRING
+{
+    uint16_t Length;
+    uint16_t MaximumLength;
+    wchar_t* Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _LDR_DATA_TABLE_ENTRY {
+    LIST_ENTRY InLoadOrderLinks;
+    LIST_ENTRY InMemoryOrderLinks;
+    LIST_ENTRY InInitOrderModuleList;
+    void* DllBase;
+    void* EntryPoint;
+    void* Reserved3;
+    UNICODE_STRING FullDllName;
+    UNICODE_STRING BaseDllName;
+} LDR_DATA_TABLE_ENTRY, *PLDR_DATA_TABLE_ENTRY;
+
+typedef struct _IMAGE_DOS_HEADER
+{
+    uint16_t e_magic;
+    uint16_t e_cblp;
+    uint16_t e_cp;
+    uint16_t e_crlc;
+    uint16_t e_cparhdr;
+    uint16_t e_minalloc;
+    uint16_t e_maxalloc;
+    uint16_t e_ss;
+    uint16_t e_sp;
+    uint16_t e_csum;
+    uint16_t e_ip;
+    uint16_t e_cs;
+    uint16_t e_lfarlc;
+    uint16_t e_ovno;
+    uint16_t e_res[4];
+    uint16_t e_oemid;
+    uint16_t e_oeminfo;
+    uint16_t e_res2[10];
+    uint32_t e_lfanew;
+} IMAGE_DOS_HEADER, *PIMAGE_DOS_HEADER;
+
+typedef struct _IMAGE_FILE_HEADER {
+    uint16_t Machine;
+    uint16_t NumberOfSections;
+    uint32_t TimeDateStamp;
+    uint32_t PointerToSymbolTable;
+    uint32_t NumberOfSymbols;
+    uint16_t SizeOfOptionalHeader;
+    uint16_t Characteristics;
+} IMAGE_FILE_HEADER, *PIMAGE_FILE_HEADER;
+
+typedef struct _IMAGE_DATA_DIRECTORY {
+    uint32_t VirtualAddress;
+    uint32_t Size;
+} IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+
+typedef struct _IMAGE_OPTIONAL_HEADER {
+    uint16_t Magic;
+    uint8_t MajorLinkerVersion;
+    uint8_t MinorLinkerVersion;
+    uint32_t SizeOfCode;
+    uint32_t SizeOfInitializedData;
+    uint32_t SizeOfUninitializedData;
+    uint32_t AddressOfEntryPoint;
+    uint32_t BaseOfCode;
+    void* ImageBase;
+    uint32_t SectionAlignment;
+    uint32_t FileAlignment;
+    uint16_t MajorOperatingSystemVersion;
+    uint16_t MinorOperatingSystemVersion;
+    uint16_t MajorImageVersion;
+    uint16_t MinorImageVersion;
+    uint16_t MajorSubsystemVersion;
+    uint16_t MinorSubsystemVersion;
+    uint32_t Win32VersionValue;
+    uint32_t SizeOfImage;
+    uint32_t SizeOfHeaders;
+    uint32_t CheckSum;
+    uint16_t Subsystem;
+    uint16_t DllCharacteristics;
+    void* SizeOfStackReserve;
+    void* SizeOfStackCommit;
+    void* SizeOfHeapReserve;
+    void* SizeOfHeapCommit;
+    uint32_t LoaderFlags;
+    uint32_t NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[16];
+} IMAGE_OPTIONAL_HEADER, *PIMAGE_OPTIONAL_HEADER;
+
+typedef struct _IMAGE_NT_HEADERS {
+    uint32_t Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER OptionalHeader;
+} IMAGE_NT_HEADERS, *PIMAGE_NT_HEADERS;
+
+#define IMAGE_DIRECTORY_ENTRY_EXPORT 0
+
+typedef struct _IMAGE_EXPORT_DIRECTORY {
+     uint32_t Characteristics;
+     uint32_t TimeDateStamp;
+     uint16_t MajorVersion;
+     uint16_t MinorVersion;
+     uint32_t Name;
+     uint32_t Base;
+     uint32_t NumberOfFunctions;
+     uint32_t NumberOfNames;
+     uint32_t AddressOfFunctions;
+     uint32_t AddressOfNames;
+     uint32_t AddressOfNameOrdinals;
+ } IMAGE_EXPORT_DIRECTORY, *PIMAGE_EXPORT_DIRECTORY;
+
+#define container_of(ptr, type, member) ({ \
+                const typeof( ((type *)0)->member ) *__mptr = (ptr); \
+                (type *)( (char *)__mptr - offsetof(type, member) );})
+
+static PPEB get_peb() {
+    volatile PPEB peb;
+    #if defined(__x86_64__)
+        asm("mov %0, gs:[0x60]" : "=r"(peb));
+    #endif
+    #if defined(__i386__)
+        asm("mov %0, fs:[0x30]" : "=r"(peb));
+    #endif
+    return peb;
+}
+
+static wchar_t lowercase(wchar_t c) {
+    return (c >='A' && c <= 'Z') ? c - 'A' + 'a' : c;
+}
+
+static bool unicode_string_equals(PUNICODE_STRING unicodeString, const wchar_t* value) {
+    uint16_t current_length = unicodeString->Length / 2; // without null-byte
+    wchar_t* current_char = unicodeString->Buffer;
+    while(current_length > 0 && *value != 0) {
+        if(lowercase(*value) != lowercase(*current_char))
+            return false;
+        value++;
+        current_char++;
+        current_length--;
+    }
+    return current_length == 0 && *value == 0;
+}
+
+static int strcmp(const char* s1, const char* s2)
+{
+    while(*s1 && (*s1 == *s2))
+    {
+        s1++;
+        s2++;
+    }
+    return *(const unsigned char*)s1 - *(const unsigned char*)s2;
+}
+
+void* get_func_from_peb(const wchar_t* libraryName, const char* procName)
+{
+    PPEB peb = get_peb();
+    PLIST_ENTRY module_entry = peb->Ldr->InMemoryOrderModuleList.Flink;
+    while(module_entry) {
+        PLDR_DATA_TABLE_ENTRY module = container_of(module_entry, LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
+        if(unicode_string_equals(&module->BaseDllName, libraryName))
+        {
+            void* DllBase = module->DllBase;
+            PIMAGE_NT_HEADERS pDLL = DllBase + ((PIMAGE_DOS_HEADER)module->DllBase)->e_lfanew;
+            uint32_t exportsRVA = pDLL->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+            PIMAGE_EXPORT_DIRECTORY exportsDir = DllBase + exportsRVA;
+            uint32_t* names_rva_array = (uint32_t*) (DllBase + exportsDir->AddressOfNames);
+            uint32_t* function_rva_array = (uint32_t*) (DllBase + exportsDir->AddressOfFunctions);
+            uint16_t* name_ordinals_array = (uint16_t*) (DllBase + exportsDir->AddressOfNameOrdinals);
+            for(int i=0; i<exportsDir->NumberOfFunctions; ++i) {
+                char* funct_name = DllBase + names_rva_array[i];
+                uint32_t exported_RVA = function_rva_array[name_ordinals_array[i]];
+
+                if(!strcmp(procName, funct_name)) {
+                    return (void*) (DllBase + exported_RVA);
+                }
+            }
+            return NULL;
+        }
+        module_entry = module_entry->Flink;
+    }
+    return NULL;
+}
+
+PLoadLibraryW pLoadLibraryW;
+PGetProcAddress pGetProcAddress;
+PMessageBoxA pMessageBoxA;
+PExpandEnvironmentStringsW pExpandEnvironmentStringsW;
+POutputDebugStringW pOutputDebugStringW;
+PCloseHandle pCloseHandle;
+PCreateFileW pCreateFileW;
+PReadFile pReadFile;
+PWriteFile pWriteFile;
+PCreateProcessW pCreateProcessW;
+PExitThread pExitThread;
+PSleep pSleep;
+PVirtualFree pVirtualFree;
+PGetLastError pGetLastError;
+
+bool load_winapi() {
+    HANDLE hKernel32, hUser32;
+
+    pLoadLibraryW = get_func_from_peb(L"kernel32.dll", "LoadLibraryW");
+    pGetProcAddress = get_func_from_peb(L"kernel32.dll", "GetProcAddress");
+    if(!pLoadLibraryW || !pGetProcAddress) {
+        // Failed to find initial functions
+        return false;
+    }
+
+    hKernel32 = LoadLibraryW(L"kernel32.dll");
+    hUser32 = LoadLibraryW(L"user32.dll");
+
+    pMessageBoxA = GetProcAddress(hUser32, "MessageBoxA");
+    pExpandEnvironmentStringsW = GetProcAddress(hKernel32, "ExpandEnvironmentStringsW");
+    pOutputDebugStringW = GetProcAddress(hKernel32, "OutputDebugStringW");
+    pCloseHandle = GetProcAddress(hKernel32, "CloseHandle");
+    pCreateFileW = GetProcAddress(hKernel32, "CreateFileW");
+    pReadFile = GetProcAddress(hKernel32, "ReadFile");
+    pWriteFile = GetProcAddress(hKernel32, "WriteFile");
+    pCreateProcessW = GetProcAddress(hKernel32, "CreateProcessW");
+    pExitThread = GetProcAddress(hKernel32, "ExitThread");
+    pSleep = GetProcAddress(hKernel32, "Sleep");
+    pVirtualFree = GetProcAddress(hKernel32, "VirtualFree");
+    pGetLastError = GetProcAddress(hKernel32, "GetLastError");
+
+    return true;
+}

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -229,6 +229,7 @@ PCancelIo pCancelIo;
 PGetExitCodeProcess pGetExitCodeProcess;
 PTerminateProcess pTerminateProcess;
 PCreateNamedPipeW pCreateNamedPipeW;
+PWaitForSingleObject pWaitForSingleObject;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -266,6 +267,7 @@ bool load_winapi() {
     pGetExitCodeProcess = GetProcAddress(hKernel32, "GetExitCodeProcess");
     pTerminateProcess = GetProcAddress(hKernel32, "TerminateProcess");
     pCreateNamedPipeW = GetProcAddress(hKernel32, "CreateNamedPipeW");
+    pWaitForSingleObject = GetProcAddress(hKernel32, "WaitForSingleObject");
 
     return true;
 }

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -230,6 +230,7 @@ PGetExitCodeProcess pGetExitCodeProcess;
 PTerminateProcess pTerminateProcess;
 PCreateNamedPipeW pCreateNamedPipeW;
 PWaitForSingleObject pWaitForSingleObject;
+PSetLastError pSetLastError;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -268,6 +269,7 @@ bool load_winapi() {
     pTerminateProcess = GetProcAddress(hKernel32, "TerminateProcess");
     pCreateNamedPipeW = GetProcAddress(hKernel32, "CreateNamedPipeW");
     pWaitForSingleObject = GetProcAddress(hKernel32, "WaitForSingleObject");
+    pSetLastError = GetProcAddress(hKernel32, "SetLastError");
 
     return true;
 }

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -228,6 +228,7 @@ PGetOverlappedResult pGetOverlappedResult;
 PCancelIo pCancelIo;
 PGetExitCodeProcess pGetExitCodeProcess;
 PTerminateProcess pTerminateProcess;
+PCreateNamedPipeW pCreateNamedPipeW;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -264,6 +265,7 @@ bool load_winapi() {
     pCancelIo = GetProcAddress(hKernel32, "CancelIo");
     pGetExitCodeProcess = GetProcAddress(hKernel32, "GetExitCodeProcess");
     pTerminateProcess = GetProcAddress(hKernel32, "TerminateProcess");
+    pCreateNamedPipeW = GetProcAddress(hKernel32, "CreateNamedPipeW");
 
     return true;
 }

--- a/drakshell/guest/nt_loader.c
+++ b/drakshell/guest/nt_loader.c
@@ -224,6 +224,10 @@ PCreatePipe pCreatePipe;
 PSetHandleInformation pSetHandleInformation;
 PWaitForMultipleObjects pWaitForMultipleObjects;
 PCreateEvent pCreateEvent;
+PGetOverlappedResult pGetOverlappedResult;
+PCancelIo pCancelIo;
+PGetExitCodeProcess pGetExitCodeProcess;
+PTerminateProcess pTerminateProcess;
 
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
@@ -256,6 +260,10 @@ bool load_winapi() {
     pSetHandleInformation = GetProcAddress(hKernel32, "SetHandleInformation");
     pWaitForMultipleObjects = GetProcAddress(hKernel32, "WaitForMultipleObjects");
     pCreateEvent = GetProcAddress(hKernel32, "CreateEventA");
+    pGetOverlappedResult = GetProcAddress(hKernel32, "GetOverlappedResult");
+    pCancelIo = GetProcAddress(hKernel32, "CancelIo");
+    pGetExitCodeProcess = GetProcAddress(hKernel32, "GetExitCodeProcess");
+    pTerminateProcess = GetProcAddress(hKernel32, "TerminateProcess");
 
     return true;
 }

--- a/drakshell/guest/thread_start.S
+++ b/drakshell/guest/thread_start.S
@@ -1,0 +1,30 @@
+.intel_syntax noprefix
+.globl thread_start
+thread_start:
+
+#if defined(__x86_64__)
+    push rcx
+#endif
+#if defined(__i386__)
+    push ecx
+#endif
+    call drakshell_main
+    # This one is going to deallocate memory occupied by shellcode
+    # and finish the thread to cover up all traces of drakshell
+    # in explorer.exe
+    #
+    # We're going to jump to the VirtualFree and it is going to
+    # return to the ExitThread for us.
+#if defined(__x86_64__)
+    pop rcx
+    and rcx, -4096
+    xor rdx, rdx
+    mov r8, 0x8000
+    jmp [rip+pVirtualFree]
+#endif
+#if defined(__i386__)
+    # TODO: Deallocation for i386 not implemented
+    pop ecx
+    xor eax, eax
+    ret
+#endif


### PR DESCRIPTION
Yeah, I know that adding agent to the agentless sandbox is a funny plot-twist, but Drakvuf Sandbox needs to make series of operations on guest before analysis has even started. My previous idea has faiiled (https://github.com/CERT-Polska/drakvuf-sandbox/issues/933) and it seems we can't reliably hijack a thread in explorer.exe, especially for operations that may take a bit longer like file upload or sync command execution.

That's why I'm coming with another idea - injecting small agent using `shellcode` mode in injector that:

- spawns its own thread as soon as the code is executed
- connects to the COM1 port (which is bound to the Unix socket on the other side)
- acts like a shell, allowing to upload/download files and execute arbitrary commands on the Windows system
- disappears when no longer needed by calling VirtualFree on itself and exiting the thread

The things I don't like in this solution is that:

- we need to enable serial port device. It's not a device that can be hot-plugged so we can't reuse an existing snapshot, we need to reboot it
- it may be difficult to handle cases when we're out of sync with the agent
- it doesn't improve the injector itself
- `injector -m shellcode` declares that it works only on Win10 x64
