### PR TITLE
CI: Add Makefile for building complete wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,8 +137,7 @@ jobs:
         run: |
           chmod +x drakrun/drakrun/tools/*  # gh artifacts don't keep file permissions
           cd drakrun
-          ( cd drakrun/web/frontend ; npm install && npm run-script build )
-          python3 setup.py bdist_wheel
+          make DIST=1
       - uses: actions/upload-artifact@v3
         with:
           name: drakvuf-sandbox-whl

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -181,7 +181,7 @@ Building from sources
 
     $ git clone --recursive git@github.com:CERT-Polska/drakvuf-sandbox.git
 
-2. Build and install Drakvuf from sources using [instructions from the official Drakvuf documentation](https://drakvuf.com/). It's recommended to use version pinned to the submodule.
+2. Build and install Drakvuf from sources using `instructions from the official Drakvuf documentation <https://drakvuf.com/>`_. It's recommended to use version pinned to the submodule.
 
 3. Install DRAKVUF Sandbox system dependencies
 

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -171,3 +171,38 @@ It's also recommended to perform all installation activities using ``root`` user
     Add ``--no-report`` if you don't want ``draksetup`` to send `basic usage report <https://github.com/CERT-Polska/drakvuf-sandbox/blob/master/USAGE_STATISTICS.md>`_. 
 
 16. Test your installation by navigating to the web interface ( http://localhost:6300/ ) and uploading some samples. The default analysis time is 10 minutes.
+
+Building from sources
+=====================
+
+1. Clone Drakvuf Sandbox repository including submodules
+
+  .. code-block:: console
+
+    $ git clone --recursive git@github.com:CERT-Polska/drakvuf-sandbox.git
+
+2. Build and install Drakvuf from sources using [instructions from the official Drakvuf documentation](https://drakvuf.com/). It's recommended to use version pinned to the submodule.
+
+3. Install DRAKVUF Sandbox system dependencies
+
+    .. code-block:: console
+
+      $ apt install tcpdump genisoimage qemu-utils bridge-utils dnsmasq libmagic1
+
+4. Install additional Web build dependencies
+
+    .. code-block:: console
+
+      $ apt install nodejs npm
+
+5. Make and install DRAKVUF Sandbox Python wheel. It's highly recommended to use `virtualenv <https://docs.python.org/3/library/venv.html>`_.
+
+    .. code-block:: console
+
+      $ python3 -m venv venv
+      $ source venv/bin/activate
+      $ cd drakrun
+      $ make
+      $ make install
+
+6. Follow the :ref:`Basic installation` starting from the Step 2. Redis, MinIO and Drakvuf Sandbox configuration.

--- a/drakrun/.gitignore
+++ b/drakrun/.gitignore
@@ -1,2 +1,3 @@
 build/
 drakrun.egg-info/
+dist/

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -1,0 +1,30 @@
+WEB_SOURCE_FILES := $(find drakrun/web/frontend/src -name '*.js' -or -name '*.css')
+PYTHON_SOURCE_FILES := $( find drakrun -name '*.py' ) drakrun/data pyproject.toml MANIFEST.in requirements.txt setup.py
+
+.PHONY: all
+all: dist/*.whl
+
+dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
+	python3 setup.py bdist_wheel
+
+drakrun/web/frontend/build: drakrun/web/frontend/node_modules $(WEB_SOURCE_FILES) drakrun/web/frontend/public
+	cd drakrun/web/frontend ; npm run build
+
+drakrun/web/frontend/node_modules: drakrun/web/frontend/package.json drakrun/web/frontend/package-lock.json
+	cd drakrun/web/frontend ; npm ci
+
+drakrun/tools/get-explorer-pid: drakrun/tools/get-explorer-pid.c
+	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
+
+drakrun/tools/test-altp2m: drakrun/tools/test-altp2m.c
+	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
+
+.PHONY: clean
+clean:
+	rm -rf dist drakvuf_sandbox.egg-info build
+	rm -rf drakrun/web/frontend/build drakrun/web/frontend/node_modules
+	rm -f drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
+
+.PHONY: install
+install: all
+	pip install dist/*.whl

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -7,9 +7,10 @@ all: dist/*.whl
 dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
 	rm -f dist/*.whl
 ifndef DIST
-	export DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD)
-endif
+	DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD) python3 setup.py bdist_wheel
+else
 	python3 setup.py bdist_wheel
+endif
 
 drakrun/web/frontend/build: drakrun/web/frontend/node_modules $(WEB_SOURCE_FILES) drakrun/web/frontend/public
 	cd drakrun/web/frontend ; npm run build

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -9,7 +9,7 @@ dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-
 ifdef DIST
 	python3 setup.py bdist_wheel
 else
-	DRAKRUN_VERSION_TAG=$(git rev-parse --short HEAD) python3 setup.py bdist_wheel
+	DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD) python3 setup.py bdist_wheel
 endif
 
 drakrun/web/frontend/build: drakrun/web/frontend/node_modules $(WEB_SOURCE_FILES) drakrun/web/frontend/public

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -5,7 +5,12 @@ PYTHON_SOURCE_FILES := $( find drakrun -name '*.py' ) drakrun/data pyproject.tom
 all: dist/*.whl
 
 dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
+	rm -f dist/*.whl
+ifdef DIST
 	python3 setup.py bdist_wheel
+else
+	DRAKRUN_VERSION_TAG=$(git rev-parse --short HEAD) python3 setup.py bdist_wheel
+endif
 
 drakrun/web/frontend/build: drakrun/web/frontend/node_modules $(WEB_SOURCE_FILES) drakrun/web/frontend/public
 	cd drakrun/web/frontend ; npm run build

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -1,16 +1,15 @@
-WEB_SOURCE_FILES := $(find drakrun/web/frontend/src -name '*.js' -or -name '*.css')
-PYTHON_SOURCE_FILES := $( find drakrun -name '*.py' ) drakrun/data pyproject.toml MANIFEST.in requirements.txt setup.py
+WEB_SOURCE_FILES := $(wildcard *.js *.css)
+PYTHON_SOURCE_FILES := $( wildcard *.py ) drakrun/data pyproject.toml MANIFEST.in requirements.txt setup.py
 
 .PHONY: all
 all: dist/*.whl
 
 dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
 	rm -f dist/*.whl
-ifdef DIST
-	python3 setup.py bdist_wheel
-else
-	DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD) python3 setup.py bdist_wheel
+ifndef DIST
+	export DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD)
 endif
+	python3 setup.py bdist_wheel
 
 drakrun/web/frontend/build: drakrun/web/frontend/node_modules $(WEB_SOURCE_FILES) drakrun/web/frontend/public
 	cd drakrun/web/frontend ; npm run build


### PR DESCRIPTION
Until this moment I was a bit lazy and was fetching the .whl package from CI artifacts for manual testing. That's why in this PR I have:

- added `Makefile` to build and install Drakvuf Sandbox package from sources 
- modified CI to use make to actually build the whole .whl package
- added proper documentation
