### PR TITLE
CI: Consistent linking with XTF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,23 +91,13 @@ jobs:
             /build/usr/lib/libvmi*
             /build/usr/include/libvmi/*
           key: drakvuf-bundle-${{ env.DRAKVUF_COMMIT }}-${{ matrix.distro }}-${{ matrix.version }}
-      - if: ${{ steps.cache-drakvuf-bundle.outputs.cache-hit != 'true' }}
-        name: Build Xen Test Framework
-        working-directory: /opt
-        run: |
-          apt install -y make pkg-config gcc libglib2.0-dev
-          git clone https://xenbits.xen.org/git-http/xtf.git
-          cd xtf
-          git checkout bf1c4eb6cb52785cf539eb83752dfcecfe66c5d1
-          make -j4
       - name: Build draksetup tools
         run: |
-          apt install -y libjson-c-dev
+          apt install -y make pkg-config gcc libglib2.0-dev libjson-c-dev
           cp -v /build/usr/lib/libvmi* /usr/lib/
           mkdir /usr/include/libvmi
           cp -v /build/usr/include/libvmi/* /usr/include/libvmi/
           make -C ./drakrun/drakrun/tools
-          cp /opt/xtf/tests/example/test-hvm64-example ./drakrun/drakrun/tools/
       - uses: actions/upload-artifact@v3
         with:
           name: drakvuf-bundle-debs-${{ matrix.distro }}-${{ matrix.version }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/mandiant/capa-rules/
 [submodule "drakrun/drakrun/tools/xtf"]
 	path = drakrun/drakrun/tools/xtf
-	url = https://xenbits.xen.org/git-http/xtf.git
+	url = https://github.com/andyhhp/xtf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "drakrun/drakrun/lib/postprocessing/capa_plugin/capa-rules"]
 	path = drakrun/drakrun/data/capa-rules
 	url = https://github.com/mandiant/capa-rules/
+[submodule "drakrun/drakrun/tools/xtf"]
+	path = drakrun/drakrun/tools/xtf
+	url = https://xenbits.xen.org/git-http/xtf.git

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -4,7 +4,7 @@ PYTHON_SOURCE_FILES := $( wildcard *.py ) drakrun/data pyproject.toml MANIFEST.i
 .PHONY: all
 all: dist/*.whl
 
-dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m
+dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/test-altp2m drakrun/tools/test-hvm64-example
 	rm -f dist/*.whl
 ifndef DIST
 	DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD) python3 setup.py bdist_wheel
@@ -23,6 +23,10 @@ drakrun/tools/get-explorer-pid: drakrun/tools/get-explorer-pid.c
 
 drakrun/tools/test-altp2m: drakrun/tools/test-altp2m.c
 	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
+
+drakrun/tools/test-hvm64-example: drakrun/tools/xtf
+	$(MAKE) -C drakrun/tools/xtf
+	cp drakrun/tools/xtf/tests/example/test-hvm64-example drakrun/tools/test-hvm64-example
 
 .PHONY: clean
 clean:

--- a/drakrun/drakrun/tools/Makefile
+++ b/drakrun/drakrun/tools/Makefile
@@ -8,3 +8,6 @@ get-explorer-pid: get-explorer-pid.c
 test-altp2m: test-altp2m.c
 	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
 
+test-hvm64-example: xtf
+	$(MAKE) -C xtf
+	cp xtf/tests/example/test-hvm64-example .


### PR DESCRIPTION
Makefile doesn't build `test-hvm64-example` XTF tool, it's build only in CI workflow.

This PR adds proper submodule and proper Makefile instructions.