### PR TITLE
Fix: don't lint tools and data

### DIFF
--- a/drakrun/.flake8
+++ b/drakrun/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 extend-ignore=E501,E203
 max-line-length=88
+exclude=drakrun/data,drakrun/tools

--- a/drakrun/pyproject.toml
+++ b/drakrun/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.isort]
 profile = "black"
+skip_glob = ["drakrun/data/**/*", "drakrun/tools/**/*"]
+
+[tool.black]
+exclude = "drakrun/(data|tools)"
 
 [tool.lint-python]
 lint-version = "2"


### PR DESCRIPTION
Right now linters try to lint code of external dependencies. We need exclusions for directories containing submodules.