### PR TITLE
Fix: missing dirs creation by 'draksetup init'

### DIFF
--- a/drakrun/drakrun/draksetup/init.py
+++ b/drakrun/drakrun/draksetup/init.py
@@ -15,6 +15,8 @@ from drakrun.lib.config import DrakrunConfig, load_config, update_config
 from drakrun.lib.minio import get_minio_client
 from drakrun.lib.paths import ETC_DIR, PACKAGE_DIR
 
+from .util.ensure_dirs import ensure_dirs
+
 log = logging.getLogger(__name__)
 
 MINIO_ENV_CONFIG_FILE = Path("/etc/default/minio")
@@ -71,11 +73,9 @@ def init(
     # Simple activities handled by deb packages before
     # In the future, consider splitting this to remove hard dependency on systemd etc
     drakrun_dir = Path(ETC_DIR)
-    scripts_dir = drakrun_dir / "scripts"
     data_dir = PACKAGE_DIR / "data"
 
-    drakrun_dir.mkdir(exist_ok=True)
-    scripts_dir.mkdir(exist_ok=True)
+    ensure_dirs()
 
     def create_configuration_file(config_file_name, target_dir=drakrun_dir):
         target_path = target_dir / config_file_name

--- a/drakrun/drakrun/draksetup/util/ensure_dirs.py
+++ b/drakrun/drakrun/draksetup/util/ensure_dirs.py
@@ -5,6 +5,7 @@ from drakrun.lib.paths import (
     ETC_DIR,
     LIB_DIR,
     PROFILE_DIR,
+    SCRIPTS_DIR,
     VM_CONFIG_DIR,
     VOLUME_DIR,
 )
@@ -13,6 +14,7 @@ from drakrun.lib.paths import (
 def ensure_dirs():
     os.makedirs(ETC_DIR, exist_ok=True)
     os.makedirs(VM_CONFIG_DIR, exist_ok=True)
+    os.makedirs(SCRIPTS_DIR, exist_ok=True)
 
     os.makedirs(LIB_DIR, exist_ok=True)
     os.makedirs(PROFILE_DIR, exist_ok=True)

--- a/drakrun/drakrun/lib/paths.py
+++ b/drakrun/drakrun/lib/paths.py
@@ -3,6 +3,7 @@ import pathlib
 
 ETC_DIR = "/etc/drakrun"
 VM_CONFIG_DIR = os.path.join(ETC_DIR, "configs")
+SCRIPTS_DIR = os.path.join(ETC_DIR, "scripts")
 
 LIB_DIR = "/var/lib/drakrun"
 PROFILE_DIR = os.path.join(LIB_DIR, "profiles")


### PR DESCRIPTION
`draksetup init` doesn't create all directories, including `/var/lib/drakrun`. This PR fixes this problem.