### PR TITLE
Allow 0 in draksetup scale to disable services, don't enable first drakrun worker on draksetup postinstall

### DIFF
--- a/drakrun/drakrun/draksetup/postinstall.py
+++ b/drakrun/drakrun/draksetup/postinstall.py
@@ -60,9 +60,6 @@ def postinstall(generate_apivectors_profile):
     create_vm_profiles(generate_apivectors_profile)
 
     log.info("All right, drakrun setup is done.")
-    log.info("First instance of drakrun will be enabled automatically...")
-    subprocess.check_output("systemctl enable drakrun@1", shell=True)
-    subprocess.check_output("systemctl start drakrun@1", shell=True)
-
-    log.info("If you want to have more parallel instances, execute:")
-    log.info("  # draksetup scale <number of instances>")
+    log.info("If you want to enable drakrun worker, execute:")
+    log.info("  # draksetup scale 1")
+    log.info("or provide a higher number if you want to have more parallel VMs")

--- a/drakrun/drakrun/draksetup/scale.py
+++ b/drakrun/drakrun/draksetup/scale.py
@@ -12,8 +12,10 @@ log = logging.getLogger(__name__)
 @click.argument("scale_count", type=int)
 def scale(scale_count):
     """Enable or disable additional parallel instances of drakrun service.."""
-    if scale_count < 1:
-        raise RuntimeError("Invalid value of scale parameter. Must be at least 1.")
+    if scale_count >= 0:
+        raise RuntimeError(
+            "Invalid value of scale parameter - must be a positive number."
+        )
 
     cur_services = set(list(get_enabled_drakruns()))
     new_services = set([f"drakrun@{i}.service" for i in range(1, scale_count + 1)])


### PR DESCRIPTION
- `draksetup scale 0` would be very useful command to stop drakrun services. This PR allows to set 0 as number of instances
- `draksetup postinstall` enables new drakrun instance automatically which is sometimes pretty annoying and unexpected. It's more clear to let user enable new worker manually by typing "draksetup scale 1"