### PR TITLE
InstallInfo and StorageBackend reworked

### DIFF
--- a/drakrun/drakrun/lib/install_info.py
+++ b/drakrun/drakrun/lib/install_info.py
@@ -1,15 +1,13 @@
 import json
 import pathlib
-from dataclasses import dataclass
 from typing import Optional
 
-from dataclasses_json import DataClassJsonMixin
+from pydantic import BaseModel
 
 from .paths import SNAPSHOT_DIR, XL_CFG_TEMPLATE_PATH
 
 
-@dataclass
-class InstallInfo(DataClassJsonMixin):
+class InstallInfo(BaseModel):
     """
     This object is main configuration of the VM, initialized during installation process.
 
@@ -23,8 +21,8 @@ class InstallInfo(DataClassJsonMixin):
     memory: int
     reboot_vm0_action: str = "restart"
     reboot_vmn_action: str = "destroy"
-    xl_cfg_template: str = XL_CFG_TEMPLATE_PATH.as_posix()
-    snapshot_dir: str = SNAPSHOT_DIR.as_posix()
+    xl_cfg_template: pathlib.Path = XL_CFG_TEMPLATE_PATH
+    snapshot_dir: pathlib.Path = SNAPSHOT_DIR
 
     lvm_snapshot_size: str = "1G"
     zfs_tank_name: Optional[str] = None
@@ -34,9 +32,9 @@ class InstallInfo(DataClassJsonMixin):
     def load(path: pathlib.Path) -> "InstallInfo":
         """Parses InstallInfo file at the provided path"""
         with path.open("r") as f:
-            return InstallInfo.from_json(f.read())
+            return InstallInfo.model_validate_json(f.read())
 
     def save(self, path: pathlib.Path) -> None:
         """Serializes self and writes to the provided path"""
         with path.open("w") as f:
-            f.write(json.dumps(self.to_dict(), indent=4))
+            f.write(json.dumps(self.model_dump(mode="json"), indent=4))

--- a/drakrun/drakrun/lib/install_info.py
+++ b/drakrun/drakrun/lib/install_info.py
@@ -1,48 +1,42 @@
 import json
-import os
+import pathlib
 from dataclasses import dataclass
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
 
-from .paths import ETC_DIR
-from .util import safe_delete
+from .paths import SNAPSHOT_DIR, XL_CFG_TEMPLATE_PATH
 
 
 @dataclass
 class InstallInfo(DataClassJsonMixin):
+    """
+    This object is main configuration of the VM, initialized during installation process.
+
+    Values are mapped to the xl domain configuration file template.
+    """
+
     storage_backend: str
     disk_size: str
-    iso_path: str
-    enable_unattended: bool
-    vcpus: int = 2
-    memory: int = 3072
+    vnc_passwd: str
+    vcpus: int
+    memory: int
+    reboot_vm0_action: str = "restart"
+    reboot_vmn_action: str = "destroy"
+    xl_cfg_template: str = XL_CFG_TEMPLATE_PATH.as_posix()
+    snapshot_dir: str = SNAPSHOT_DIR.as_posix()
+
+    lvm_snapshot_size: str = "1G"
     zfs_tank_name: Optional[str] = None
     lvm_volume_group: Optional[str] = None
-    iso_sha256: Optional[str] = None
-
-    INSTALL_FILE_PATH = os.path.join(ETC_DIR, "install.json")
 
     @staticmethod
-    def load() -> "InstallInfo":
-        """Reads and parses install.json file"""
-        with open(InstallInfo.INSTALL_FILE_PATH, "r") as f:
+    def load(path: pathlib.Path) -> "InstallInfo":
+        """Parses InstallInfo file at the provided path"""
+        with path.open("r") as f:
             return InstallInfo.from_json(f.read())
 
-    @staticmethod
-    def try_load() -> Optional["InstallInfo"]:
-        """Tries to load install.json of fails with None"""
-        try:
-            return InstallInfo.load()
-        except FileNotFoundError:
-            return None
-
-    @staticmethod
-    def delete():
-        if not safe_delete(InstallInfo.INSTALL_FILE_PATH):
-            raise Exception("install.json not deleted")
-
-    def save(self):
-        """Serializes self and writes to install.json"""
-        with open(InstallInfo.INSTALL_FILE_PATH, "w") as f:
+    def save(self, path: pathlib.Path) -> None:
+        """Serializes self and writes to the provided path"""
+        with path.open("w") as f:
             f.write(json.dumps(self.to_dict(), indent=4))

--- a/drakrun/drakrun/lib/paths.py
+++ b/drakrun/drakrun/lib/paths.py
@@ -13,3 +13,6 @@ VOLUME_DIR = os.path.join(LIB_DIR, "volumes")
 CONFIG_PATH = os.path.join(ETC_DIR, "config.ini")
 
 PACKAGE_DIR = pathlib.Path(__file__).parent.parent.absolute()
+
+SNAPSHOT_DIR = pathlib.Path(VOLUME_DIR)
+XL_CFG_TEMPLATE_PATH = pathlib.Path(SCRIPTS_DIR) / "cfg.template"

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -13,7 +13,7 @@ ipython==8.10.0
 flare-capa>=7.2.0
 orjson==3.9.15
 mslex==1.1.0
-pydantic==2.6.4
+pydantic==2.11.0
 # Peer dependency of Pydantic
 typing-extensions
 pathvalidate==3.2.0

--- a/drakrun/requirements.txt
+++ b/drakrun/requirements.txt
@@ -13,7 +13,7 @@ ipython==8.10.0
 flare-capa>=7.2.0
 orjson==3.9.15
 mslex==1.1.0
-pydantic==2.11.0
+pydantic==2.10.6
 # Peer dependency of Pydantic
 typing-extensions
 pathvalidate==3.2.0


### PR DESCRIPTION
StorageBackend objects should have single source of configuration (InstallInfo), right now it's a bit scattered over the file.

This PR also adds:
- new fields in InstallInfo that should contain everything that is mapped to xl.cfg.template.
- InstallInfo uses Pydantic instead of dataclasses_json
- removed unnecessary shell calls
- lvm_snapshot_size isn't just a magic hardcoded number but a configurable field
- removed `enable_unattended`, `iso_path` and `iso_sha256` fields. It's not a VM state and we don't care about it further.

This is an isolated patch from my internal rework of drakrun and may be incompatible with other parts of code right now. I just want to have reasonable diffs in commits.