### PR TITLE
drakshell v2: bootstrap agent to assist injector in VM provisioning phase

### DIFF
--- a/drakrun/MANIFEST.in
+++ b/drakrun/MANIFEST.in
@@ -1,5 +1,6 @@
-include drakrun/tools/*
 include drakrun/test/*
 include drakrun/data/*
+include draktools/tools/get-explorer-pid
+include draktools/tools/drakshell/drakshell
 recursive-include drakrun/data/capa-rules *.yml
 recursive-include drakrun/web/frontend/build *

--- a/drakrun/Makefile
+++ b/drakrun/Makefile
@@ -4,7 +4,7 @@ PYTHON_SOURCE_FILES := $( wildcard *.py ) drakrun/data pyproject.toml MANIFEST.i
 .PHONY: all
 all: dist/*.whl
 
-dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid
+dist/*.whl: $(PYTHON_SOURCE_FILES) drakrun/web/frontend/build drakrun/tools/get-explorer-pid drakrun/tools/drakshell/drakshell
 	rm -f dist/*.whl
 ifndef DIST
 	DRAKRUN_VERSION_TAG=$(shell git rev-parse --short HEAD) python3 setup.py bdist_wheel
@@ -20,6 +20,9 @@ drakrun/web/frontend/node_modules: drakrun/web/frontend/package.json drakrun/web
 
 drakrun/tools/get-explorer-pid: drakrun/tools/get-explorer-pid.c
 	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
+
+drakrun/tools/drakshell/drakshell:
+	cd drakrun/tools/drakshell && make $@
 
 .PHONY: clean
 clean:

--- a/drakrun/drakrun/draksetup/drakshell.py
+++ b/drakrun/drakrun/draksetup/drakshell.py
@@ -1,0 +1,81 @@
+import logging
+import signal
+import sys
+import time
+
+import click
+
+from drakrun.lib.drakshell import Drakshell
+from drakrun.lib.injector import Injector
+from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.libvmi import VmiInfo
+from drakrun.lib.network_info import NetworkConfiguration
+from drakrun.lib.paths import (
+    INSTALL_INFO_PATH,
+    NETWORK_CONF_PATH,
+    PACKAGE_TOOLS_PATH,
+    VMI_INFO_PATH,
+    VMI_KERNEL_PROFILE_PATH,
+)
+from drakrun.lib.vm import VirtualMachine
+
+log = logging.getLogger(__name__)
+
+
+@click.command("drakshell")
+@click.option(
+    "--vm-id",
+    "vm_id",
+    default=1,
+    type=int,
+    show_default=True,
+    help="VM id to use for generating profile",
+)
+@click.argument("cmd", nargs=-1, type=str)
+def drakshell(vm_id, cmd):
+    install_info = InstallInfo.load(INSTALL_INFO_PATH)
+    network_conf = NetworkConfiguration.load(NETWORK_CONF_PATH)
+    vm = VirtualMachine(vm_id, install_info, network_conf)
+    if not vm.is_running:
+        click.echo("VM is not running", err=True)
+        raise click.Abort()
+    vmi_info = VmiInfo.load(VMI_INFO_PATH)
+    injector = Injector(vm.vm_name, vmi_info, VMI_KERNEL_PROFILE_PATH)
+
+    drakshell = Drakshell(vm.vm_name)
+    connected = False
+    try:
+        drakshell.connect()
+        connected = True
+    except Exception as e:
+        log.warning(f"Failed to connect to drakshell: {str(e)}")
+
+    if not connected:
+        log.info("Injecting drakshell...")
+        drakshell_path = (
+            (PACKAGE_TOOLS_PATH / "drakshell" / "drakshell").resolve().as_posix()
+        )
+        injector.inject_shellcode(drakshell_path)
+        log.info("Injected. Trying to connect.")
+        time.sleep(1)
+        drakshell.connect()
+
+    info = drakshell.get_info()
+    log.info(f"Drakshell active on: {str(info)}")
+
+    process = drakshell.run_interactive(cmd, sys.stdin, sys.stdout, sys.stderr)
+
+    # We can't rely on KeyboardInterrupt because threads are immediately terminated
+    # when signal handler raises an Exception. I don't know why it works that way
+    # but we need to setup our own handler here.
+    orig_handler = signal.getsignal(signal.SIGINT)
+
+    def sigint_handler(sig, frame):
+        process.terminate()
+
+    signal.signal(signal.SIGINT, sigint_handler)
+    try:
+        exit_code = process.join()
+        log.info(f"Process terminated with exit code {exit_code}")
+    finally:
+        signal.signal(signal.SIGINT, orig_handler)

--- a/drakrun/drakrun/draksetup/main.py
+++ b/drakrun/drakrun/draksetup/main.py
@@ -3,6 +3,7 @@ import os
 
 import click
 
+from .drakshell import drakshell
 from .drakvuf_cmdline import drakvuf_cmdline
 from .injector import injector
 from .install import install
@@ -25,6 +26,7 @@ def main():
         raise click.Abort()
 
 
+main.add_command(drakshell)
 main.add_command(drakvuf_cmdline)
 main.add_command(install)
 main.add_command(postinstall)

--- a/drakrun/drakrun/lib/drakshell.py
+++ b/drakrun/drakrun/lib/drakshell.py
@@ -180,9 +180,8 @@ class DrakshellInteractiveProcess:
                         status, data = self.channel.recv_response(timeout=3)
                     except Exception as e:
                         if _exc is not None:
-                            raise ExceptionGroup(
-                                "Exception raised during exception handling", (e, _exc)
-                            )
+                            # I don't know how to handle it now
+                            raise
                         else:
                             self.terminate()
                             _exc = e

--- a/drakrun/drakrun/lib/drakshell.py
+++ b/drakrun/drakrun/lib/drakshell.py
@@ -1,3 +1,329 @@
+import enum
+import logging
+import os
+import select
+import socket
+import struct
+import sys
+import threading
+import time
+
+import mslex
+
+from .paths import PACKAGE_TOOLS_PATH, RUN_DIR
+
+log = logging.getLogger(__name__)
+
+
+class ReqCode(enum.IntEnum):
+    REQ_PING = 0xA0
+    REQ_GET_INFO = 0xA1
+    REQ_INTERACTIVE_EXECUTE = 0xA2
+    REQ_NON_INTERACTIVE_EXECUTE = 0xA3
+    REQ_EXECUTE_AND_FINISH = 0xA4
+    REQ_FINISH = 0xA5
+    REQ_DATA = 0xA6
+    REQ_TERMINATE_PROCESS = 0xA7
+
+
+class RespCode(enum.IntEnum):
+    RESP_PONG = 0xA0
+    RESP_INFO = 0xA1
+    RESP_INTERACTIVE_EXECUTE_START = 0xA2
+    RESP_NON_INTERACTIVE_EXECUTE_START = 0xA3
+    RESP_EXECUTE_AND_FINISH_START = 0xA4
+    RESP_FINISH_START = 0xA5
+    RESP_STDOUT_DATA = 0xA6
+    RESP_STDERR_DATA = 0xA7
+    RESP_PROCESS_START = 0xA8
+    RESP_PROCESS_EXIT = 0xA9
+    RESP_BAD_REQ = 0xB0
+    RESP_FATAL_ERROR = 0xB1
+    RESP_PROCESS_ERROR = 0xB2
+
+
+class Channel:
+    MAX_BUFFER_SIZE = 4096
+
+    def __init__(self, unix_socket_path):
+        self.unix_socket_path = unix_socket_path
+        self._sock = None
+
+    def connect(self):
+        try:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.connect(self.unix_socket_path)
+        except Exception:
+            self._sock = None
+            raise
+
+    def disconnect(self):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        self._sock.close()
+        self._sock = None
+
+    def send_control(self, req):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        msg = struct.pack("<B", int(req))
+        self._sock.send(msg)
+
+    def _recv_control(self):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        msg = self._sock.recv(1)
+        if not msg:
+            raise RuntimeError("Socket has unexpectedly disconnected")
+        return RespCode(msg[0])
+
+    def _recvn(self, size):
+        data = b""
+        while size > 0:
+            part = self._sock.recv(size)
+            if not part:
+                raise RuntimeError("Socket has unexpectedly disconnected")
+            size -= len(part)
+            data += part
+        return data
+
+    def _recv_status_code(self):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        msg = self._recvn(4)
+        if not msg:
+            raise RuntimeError("Socket has unexpectedly disconnected")
+        return struct.unpack("<I", msg)[0]
+
+    def _recv_info(self):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        msg = self._recvn(8)
+        if not msg:
+            raise RuntimeError("Socket has unexpectedly disconnected")
+        return struct.unpack("<II", msg)
+
+    def _recv_data(self):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        len_msg = self._recvn(2)
+        if not len_msg:
+            raise RuntimeError("Socket has unexpectedly disconnected")
+        arg_len = struct.unpack("<H", len_msg)[0]
+        return self._recvn(arg_len)
+
+    def send_data(self, arg):
+        if self._sock is None:
+            raise RuntimeError("Socket is not connected")
+        if len(arg) > self.MAX_BUFFER_SIZE:
+            raise ValueError("Message block too long")
+        self.send_control(ReqCode.REQ_DATA)
+        len_msg = struct.pack("<H", len(arg))
+        self._sock.send(len_msg + arg)
+
+    def recv_response(self, timeout=15):
+        self._sock.settimeout(timeout)
+        resp = self._recv_control()
+        if resp in [RespCode.RESP_STDOUT_DATA, RespCode.RESP_STDERR_DATA]:
+            block = self._recv_data()
+            return resp, block
+        elif resp in [
+            RespCode.RESP_PROCESS_EXIT,
+            RespCode.RESP_PROCESS_ERROR,
+            RespCode.RESP_FATAL_ERROR,
+        ]:
+            code = self._recv_status_code()
+            return resp, code
+        elif resp == RespCode.RESP_INFO:
+            info = self._recv_info()
+            return resp, info
+        return resp, None
+
+    def sync(self, timeout=3):
+        self.send_control(ReqCode.REQ_PING)
+        status, _ = self.recv_response(timeout=timeout)
+
+
+class InteractiveProcessExit(Exception):
+    def __init__(self, exit_code):
+        self.exit_code = exit_code
+
+
+class DrakshellInteractiveProcess:
+    def __init__(self, channel: Channel, stdin, stdout, stderr):
+        self.channel = channel
+        self.terminated = False
+
+        self._exit_code = None
+        self._fatal_error = None
+        self._stdin = stdin
+        self._stdout = stdout
+        self._stderr = stderr
+        self._thread = threading.Thread(target=self.handler)
+        self._thread.start()
+
+    def _handle_streams(self):
+        _exc = None
+        while True:
+            ready_list, _, _ = select.select(
+                [self._stdin, self.channel._sock], [], [], 1
+            )
+            for ready_thing in ready_list:
+                if ready_thing is self._stdin:
+                    if self._stdin is sys.stdin:
+                        stdin_data = os.read(self._stdin.fileno(), 2048)
+                    else:
+                        stdin_data = self._stdin.recv(2048)
+                    self.channel.send_data(stdin_data)
+                else:
+                    try:
+                        status, data = self.channel.recv_response(timeout=3)
+                    except Exception as e:
+                        if _exc is not None:
+                            raise ExceptionGroup(
+                                "Exception raised during exception handling", (e, _exc)
+                            )
+                        else:
+                            self.terminate()
+                            _exc = e
+                    else:
+                        if status == RespCode.RESP_STDOUT_DATA:
+                            if hasattr(self._stdout, "send"):
+                                self._stdout.send(data)
+                            else:
+                                self._stdout.buffer.write(data)
+                                self._stdout.flush()
+                        elif status == RespCode.RESP_STDERR_DATA:
+                            if hasattr(self._stderr, "send"):
+                                self._stderr.send(data)
+                            else:
+                                self._stderr.buffer.write(data)
+                                self._stderr.flush()
+                        elif status == RespCode.RESP_PROCESS_EXIT:
+                            self.terminated = True
+                            raise InteractiveProcessExit(data)
+                        elif status == RespCode.RESP_FATAL_ERROR:
+                            self.terminated = True
+                            raise RuntimeError(f"Fatal execution error: code={data}")
+                        else:
+                            raise RuntimeError(
+                                f"Drakshell is out of sync: got {status} during process execution"
+                            )
+
+    def handler(self):
+        try:
+            self._handle_streams()
+        except InteractiveProcessExit as e:
+            self._exit_code = e.exit_code
+        except Exception as e:
+            self._fatal_error = e
+
+    def terminate(self):
+        if self.terminated:
+            return
+        self.terminated = True
+        self.channel.send_control(ReqCode.REQ_TERMINATE_PROCESS)
+
+    def join(self):
+        self._thread.join()
+        if self._exit_code is not None:
+            return self._exit_code
+        else:
+            raise self._fatal_error
+
+
+class Drakshell:
+    def __init__(self, vm_name: str):
+        self.vm_name = vm_name
+
+        unix_socket_path = RUN_DIR / f"{vm_name}.sock"
+        self.channel = Channel(str(unix_socket_path))
+
+    def connect(self):
+        self.channel.connect()
+        try:
+            self.channel.send_control(ReqCode.REQ_PING)
+            status, _ = self.channel.recv_response(timeout=3)
+            if status != RespCode.RESP_PONG:
+                raise RuntimeError(
+                    f"Drakshell is out of sync: got {status} instead of {RespCode.RESP_PONG}"
+                )
+        except Exception:
+            self.channel.disconnect()
+            raise
+
+    def disconnect(self):
+        self.channel.disconnect()
+
+    def get_info(self):
+        self.channel.send_control(ReqCode.REQ_GET_INFO)
+        status, info = self.channel.recv_response(timeout=3)
+        if status != RespCode.RESP_INFO:
+            raise RuntimeError(
+                f"Drakshell is out of sync: got {status} instead of {RespCode.RESP_INFO}"
+            )
+        return {"pid": info[0], "tid": info[1]}
+
+    def _start_process(self, args, start_code: ReqCode):
+        cmdline = mslex.join(args, for_cmd=False).encode("utf-16le") + b"\0\0"
+        if len(cmdline) > 2048:
+            raise RuntimeError("Command line too long")
+
+        expected_status = {
+            ReqCode.REQ_INTERACTIVE_EXECUTE: RespCode.RESP_INTERACTIVE_EXECUTE_START,
+            ReqCode.REQ_NON_INTERACTIVE_EXECUTE: RespCode.RESP_NON_INTERACTIVE_EXECUTE_START,
+            ReqCode.REQ_EXECUTE_AND_FINISH: RespCode.RESP_EXECUTE_AND_FINISH_START,
+        }[start_code]
+        self.channel.send_control(start_code)
+
+        status, _ = self.channel.recv_response(timeout=3)
+        if status != expected_status:
+            raise RuntimeError(
+                f"Drakshell is out of sync: got {status} instead of {expected_status}"
+            )
+
+        self.channel.send_data(cmdline)
+        status, code = self.channel.recv_response(timeout=3)
+        if status == RespCode.RESP_PROCESS_START:
+            pass
+        elif status == RespCode.RESP_PROCESS_ERROR:
+            raise RuntimeError(f"Process startup failed: {code}")
+        else:
+            raise RuntimeError(
+                f"Drakshell is out of sync: got {status} instead of {expected_status}"
+            )
+
+    def run(self, args, terminate_drakshell=False):
+        if terminate_drakshell:
+            start_code = ReqCode.REQ_EXECUTE_AND_FINISH
+        else:
+            start_code = ReqCode.REQ_NON_INTERACTIVE_EXECUTE
+
+        self._start_process(args, start_code)
+
+    def run_interactive(self, args, stdin, stdout, stderr):
+        self._start_process(args, ReqCode.REQ_INTERACTIVE_EXECUTE)
+        return DrakshellInteractiveProcess(self.channel, stdin, stdout, stderr)
+
+
 def get_drakshell(vm, injector):
-    # Just a mock...
-    return None, {"pid": 0, "tid": 0}
+    drakshell = Drakshell(vm.vm_name)
+    connected = False
+    try:
+        drakshell.connect()
+        connected = True
+    except Exception as e:
+        log.warning(f"Failed to connect to drakshell: {str(e)}")
+
+    if not connected:
+        log.info("Injecting drakshell...")
+        drakshell_path = (
+            (PACKAGE_TOOLS_PATH / "drakshell" / "drakshell").resolve().as_posix()
+        )
+        injector.inject_shellcode(drakshell_path)
+        log.info("Injected. Trying to connect.")
+        time.sleep(1)
+        drakshell.connect()
+
+    info = drakshell.get_info()
+    return drakshell, info

--- a/drakrun/drakrun/tools/Makefile
+++ b/drakrun/drakrun/tools/Makefile
@@ -2,3 +2,6 @@ all: get-explorer-pid
 
 get-explorer-pid: get-explorer-pid.c
 	gcc $< -o $@ -lvmi `pkg-config --cflags --libs glib-2.0`
+
+drakshell/drakshell:
+	cd drakshell && make $@

--- a/drakrun/drakrun/tools/drakshell/.gitignore
+++ b/drakrun/drakrun/tools/drakshell/.gitignore
@@ -1,0 +1,2 @@
+obj/*
+drakshell

--- a/drakrun/drakrun/tools/drakshell/Makefile
+++ b/drakrun/drakrun/tools/drakshell/Makefile
@@ -1,0 +1,27 @@
+IDIR =./include
+CFLAGS=-I$(IDIR) -fPIE -nostdlib -ffreestanding -masm=intel -march=haswell -fshort-wchar -O2
+LFLAGS=-T linker.ld
+ODIR=obj
+
+_DEPS = nt_loader.h
+DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
+
+_OBJ = nt_loader.o drakshell.o thread_start.o
+OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
+
+drakshell: $(ODIR)/drakshell.elf
+	objcopy -O binary -j.text -j.bss --set-section-flags .bss=alloc,load,contents $^ drakshell
+
+$(ODIR)/%.o: %.c $(DEPS)
+	gcc -c -o $@ $< $(CFLAGS)
+
+$(ODIR)/%.o: %.S $(DEPS)
+	gcc -c -o $@ $<
+
+$(ODIR)/drakshell.elf: $(OBJ)
+	gcc $(LFLAGS) -o $@ $^ $(CFLAGS)
+
+clean:
+	rm -f drakshell $(ODIR)/*.o $(ODIR)/*.elf *~ core $(INCDIR)/*~
+
+.PHONY: clean

--- a/drakrun/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/drakrun/tools/drakshell/drakshell.c
@@ -1,0 +1,891 @@
+// gcc  headless.c
+// objcopy -O binary --only-section=.text a.out out_objcopy_onlysection
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "nt_loader.h"
+
+#define REQ_PING 0xA0
+#define REQ_GET_INFO 0xA1
+#define REQ_INTERACTIVE_EXECUTE 0xA2
+#define REQ_NON_INTERACTIVE_EXECUTE 0xA3
+#define REQ_EXECUTE_AND_FINISH 0xA4
+#define REQ_FINISH 0xA5
+#define REQ_DATA 0xA6
+#define REQ_TERMINATE_PROCESS 0xA7
+
+#define RESP_PONG 0xA0
+#define RESP_INFO 0xA1
+#define RESP_INTERACTIVE_EXECUTE_START 0xA2
+#define RESP_NON_INTERACTIVE_EXECUTE_START 0xA3
+#define RESP_EXECUTE_AND_FINISH_START 0xA4
+#define RESP_FINISH_START 0xA5
+#define RESP_STDOUT_DATA 0xA6
+#define RESP_STDERR_DATA 0xA7
+#define RESP_PROCESS_START 0xA8
+#define RESP_PROCESS_EXIT 0xA9
+
+#define RESP_BAD_REQ 0xB0
+#define RESP_FATAL_ERROR 0xB1
+#define RESP_PROCESS_ERROR 0xB2
+
+static bool read(HANDLE hComm, LPBYTE buffer, LPDWORD size, DWORD maxSize) {
+    // Synchronized wrapper over async ReadFile
+    OVERLAPPED overlapped = {0};
+    DWORD result;
+    overlapped.hEvent = CreateEvent(NULL, true, true, NULL);
+    if(!ReadFile(hComm, buffer, maxSize, NULL, &overlapped)) {
+        if(GetLastError() != ERROR_IO_PENDING) {
+            return false;
+        }
+        while(true) {
+            // Schedule that thread on CPU from time to time
+            result = WaitForSingleObject(overlapped.hEvent, 50);
+            if(!result) {
+                // Signalled
+                break;
+            }
+            else if(result != WAIT_TIMEOUT)
+            {
+                // Not a WAIT_OBJECT_0 and WAIT_TIMEOUT
+                return false;
+            }
+        }
+    }
+    if(!GetOverlappedResult(hComm, &overlapped, size, false)) {
+        return false;
+    }
+    return true;
+}
+
+static bool write(HANDLE hComm, LPBYTE buffer, LPDWORD size, DWORD maxSize) {
+    // Synchronized wrapper over async WriteFile
+    OVERLAPPED overlapped = {0};
+    DWORD result;
+    overlapped.hEvent = CreateEvent(NULL, true, true, NULL);
+    if(!WriteFile(hComm, buffer, maxSize, NULL, &overlapped)) {
+        if(GetLastError() != ERROR_IO_PENDING) {
+            return false;
+        }
+        while(true) {
+            // Schedule that thread on CPU from time to time
+            result = WaitForSingleObject(overlapped.hEvent, 50);
+            if(!result) {
+                // Signalled
+                break;
+            }
+            else if(result != WAIT_TIMEOUT)
+            {
+                // Not a WAIT_OBJECT_0 and WAIT_TIMEOUT
+                return false;
+            }
+        }
+    }
+    if(!GetOverlappedResult(hComm, &overlapped, size, false)) {
+        return false;
+    }
+    return true;
+}
+
+static bool recvn(HANDLE hComm, LPBYTE buffer, DWORD size) {
+    OVERLAPPED overlapped = {0};
+    DWORD bytesRead = 0;
+
+    while(size > 0) {
+        if(!read(hComm, buffer, &bytesRead, size)) {
+            OutputDebugStringW(L"recvn: ReadFile failed");
+            return false;
+        }
+        if(!bytesRead) {
+            OutputDebugStringW(L"recvn: Broken pipe");
+            return false;
+        }
+        size -= bytesRead;
+        buffer += bytesRead;
+    }
+    return true;
+}
+
+static bool sendn(HANDLE hComm, LPBYTE buffer, DWORD size) {
+    DWORD bytesWritten = 0;
+
+    while(size > 0) {
+        if(!write(hComm, buffer, &bytesWritten, size)) {
+            OutputDebugStringW(L"sendn: WriteFile failed");
+            return false;
+        }
+        if(!bytesWritten) {
+            OutputDebugStringW(L"sendn: Broken pipe");
+            return false;
+        }
+        size -= bytesWritten;
+        buffer += bytesWritten;
+    }
+    return true;
+}
+
+static bool recv_control(HANDLE hComm, LPBYTE req) {
+    return recvn(hComm, req, sizeof(*req));
+}
+
+static bool send_control(HANDLE hComm, BYTE resp) {
+    return sendn(hComm, &resp, sizeof(resp));
+}
+
+static bool recv_data(HANDLE hComm, LPBYTE bufferToRecv, LPWORD argSize, WORD argMaxSize) {
+    if(!recvn(hComm, (LPBYTE)argSize, sizeof(*argSize))) {
+        return false;
+    }
+    if(*argSize > argMaxSize) {
+        OutputDebugStringW(L"recv_data: Buffer overflow");
+        return false;
+    }
+    return recvn(hComm, bufferToRecv, *argSize);
+}
+
+static bool send_data(HANDLE hComm, LPBYTE bufferToSend, WORD argSize) {
+    if(!sendn(hComm, (LPBYTE)&argSize, sizeof(argSize))) {
+        return false;
+    }
+    if(!argSize)
+        return true;
+    return sendn(hComm, bufferToSend, argSize);
+}
+
+static bool send_control_with_code(HANDLE hComm, BYTE resp, DWORD code) {
+    if(!send_control(hComm, resp)) {
+        return false;
+    }
+    return sendn(hComm, (LPBYTE)&code, sizeof(code));
+}
+
+static bool send_fatal_error(HANDLE hComm, DWORD gle) {
+    return send_control_with_code(hComm, RESP_FATAL_ERROR, gle);
+}
+
+static bool recv_data_to_void(HANDLE hComm) {
+    BYTE buffer[1024];
+    WORD bytesRead;
+    return recv_data(hComm, buffer, &bytesRead, sizeof(buffer));
+}
+
+typedef struct _STD_HANDLES {
+    HANDLE hStdinRead;
+    HANDLE hStdinWrite;
+    HANDLE hStdoutRead;
+    HANDLE hStdoutWrite;
+    HANDLE hStderrRead;
+    HANDLE hStderrWrite;
+} STD_HANDLES, *PSTD_HANDLES;
+
+
+static void close_std_handles(PSTD_HANDLES handles) {
+    DWORD gle = GetLastError();
+    if(handles->hStdinRead != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStdinRead);
+        handles->hStdinRead = INVALID_HANDLE_VALUE;
+    }
+    if(handles->hStdoutRead != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStdoutRead);
+        handles->hStdoutRead = INVALID_HANDLE_VALUE;
+    }
+    if(handles->hStderrRead != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStderrRead);
+        handles->hStderrRead = INVALID_HANDLE_VALUE;
+    }
+    if(handles->hStdinWrite != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStdinWrite);
+        handles->hStdinWrite = INVALID_HANDLE_VALUE;
+    }
+    if(handles->hStdoutWrite != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStdoutWrite);
+        handles->hStdoutWrite = INVALID_HANDLE_VALUE;
+    }
+    if(handles->hStderrWrite != INVALID_HANDLE_VALUE) {
+        CloseHandle(handles->hStderrWrite);
+        handles->hStderrWrite = INVALID_HANDLE_VALUE;
+    }
+    // This is a common cleanup function and we don't want to
+    // overwrite GLE coming from the faulting function
+    SetLastError(gle);
+}
+
+static bool init_std_handles(PSTD_HANDLES handles) {
+    SECURITY_ATTRIBUTES saInheritHandle;
+
+    saInheritHandle.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saInheritHandle.bInheritHandle = true;
+    saInheritHandle.lpSecurityDescriptor = NULL;
+
+    handles->hStdinRead = INVALID_HANDLE_VALUE;
+    handles->hStdinWrite = INVALID_HANDLE_VALUE;
+    handles->hStdoutRead = INVALID_HANDLE_VALUE;
+    handles->hStdoutWrite = INVALID_HANDLE_VALUE;
+    handles->hStderrRead = INVALID_HANDLE_VALUE;
+    handles->hStderrWrite = INVALID_HANDLE_VALUE;
+
+    handles->hStdinRead = CreateNamedPipe(
+        L"\\\\.\\pipe\\drakshell-stdin",
+        PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+        0, // byte & wait mode
+        1,
+        4096,
+        4096,
+        0,
+        &saInheritHandle
+    );
+
+    if(handles->hStdinRead == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateNamedPipe failed for stdin");
+        close_std_handles(handles);
+        return false;
+    }
+
+    handles->hStdinWrite = CreateFileW(
+        L"\\\\.\\pipe\\drakshell-stdin",
+        GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if(handles->hStdinWrite == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateFileW failed for stdin");
+        close_std_handles(handles);
+        return false;
+    }
+
+    handles->hStdoutWrite = CreateNamedPipe(
+        L"\\\\.\\pipe\\drakshell-stdout",
+        PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED,
+        0, // byte & wait mode
+        1,
+        4096,
+        4096,
+        0,
+        &saInheritHandle
+    );
+
+    if(handles->hStdoutWrite == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateNamedPipe failed for stdout");
+        close_std_handles(handles);
+        return false;
+    }
+
+    handles->hStdoutRead = CreateFileW(
+        L"\\\\.\\pipe\\drakshell-stdout",
+        GENERIC_READ,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if(handles->hStdoutRead == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateFileW failed for stdout");
+        close_std_handles(handles);
+        return false;
+    }
+
+    handles->hStderrWrite = CreateNamedPipe(
+        L"\\\\.\\pipe\\drakshell-stderr",
+        PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED,
+        0, // byte & wait mode
+        1,
+        4096,
+        4096,
+        0,
+        &saInheritHandle
+    );
+
+    if(handles->hStderrWrite == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateNamedPipe failed for stderr");
+        close_std_handles(handles);
+        return false;
+    }
+
+    handles->hStderrRead = CreateFileW(
+        L"\\\\.\\pipe\\drakshell-stderr",
+        GENERIC_READ,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if(handles->hStderrRead == INVALID_HANDLE_VALUE) {
+        OutputDebugStringW(L"init_std_handles: CreateFileW failed for stderr");
+        close_std_handles(handles);
+        return false;
+    }
+
+    return true;
+}
+
+static bool create_process(LPWSTR szCmdline, PSTD_HANDLES std_handles, PHANDLE lphProcess) {
+    BOOL bSuccess;
+    PROCESS_INFORMATION piProcInfo = {0};
+    STARTUPINFOW siStartInfo = {0};
+
+    siStartInfo.cb = sizeof(STARTUPINFOW);
+
+    if(std_handles != NULL) {
+        if(!init_std_handles(std_handles)) {
+            return false;
+        }
+        siStartInfo.hStdError = std_handles->hStderrWrite;
+        siStartInfo.hStdOutput = std_handles->hStdoutWrite;
+        siStartInfo.hStdInput = std_handles->hStdinRead;
+        siStartInfo.dwFlags = STARTF_USESTDHANDLES;
+    }
+
+    bSuccess = CreateProcessW(NULL,
+        szCmdline,           // command line
+        NULL,                // process security attributes
+        NULL,                // primary thread security attributes
+        std_handles != NULL, // handles are inherited if interaction is needed
+        0,                   // creation flags
+        NULL,                // use parent's environment
+        NULL,                // use parent's current directory
+        &siStartInfo,        // STARTUPINFO pointer
+        &piProcInfo          // receives PROCESS_INFORMATION
+    );
+    if(!bSuccess) {
+        if(std_handles != NULL)
+            close_std_handles(std_handles);
+        return false;
+    } else {
+        // Close handle to the main thread
+        CloseHandle(piProcInfo.hThread);
+        // Close handles to the child-side of pipes
+        // because inheritance made a duplicates
+        if(std_handles != NULL) {
+            CloseHandle(std_handles->hStderrWrite);
+            std_handles->hStderrWrite = INVALID_HANDLE_VALUE;
+            CloseHandle(std_handles->hStdoutWrite);
+            std_handles->hStdoutWrite = INVALID_HANDLE_VALUE;
+            CloseHandle(std_handles->hStdinRead);
+            std_handles->hStdinRead = INVALID_HANDLE_VALUE;
+        }
+        // Pass process handle to the caller
+        if(lphProcess != NULL) {
+            *lphProcess = piProcInfo.hProcess;
+        } else {
+            CloseHandle(piProcInfo.hProcess);
+        }
+        return true;
+    }
+}
+
+static bool process_execute(HANDLE hComm, BOOL interactive) {
+     union {
+        struct {
+            wchar_t commandLine[1024];
+        };
+        struct {
+            BYTE stdinBuffer[1024];
+            BYTE stdoutBuffer[1024];
+            BYTE stderrBuffer[1024];
+        };
+    } buffers;
+    WORD commandLineBytesRead = 0;
+    BYTE control = 0;
+    STD_HANDLES std_handles = {0};
+    HANDLE hProcess;
+
+    // Receive command line
+    if(!recv_control(hComm, &control)) {
+        send_control(hComm, RESP_BAD_REQ);
+        return false;
+    }
+    if(control != REQ_DATA) {
+        // We probably lost sync in the middle
+        // and there is another try to use drakshell.
+        // Let's finish this mode gracefully
+        if(!send_control(hComm, RESP_BAD_REQ)) {
+            return false;
+        }
+        return true;
+    }
+    if(!recv_data(hComm, (LPBYTE)buffers.commandLine, &commandLineBytesRead, sizeof(buffers.commandLine) - sizeof(wchar_t))) {
+        send_control(hComm, RESP_BAD_REQ);
+        return false;
+    }
+    // Ensure terminator at the end
+    buffers.commandLine[commandLineBytesRead] = 0;
+
+    if(!create_process(buffers.commandLine, interactive ? &std_handles : NULL, interactive ? &hProcess : NULL)) {
+        send_control_with_code(hComm, RESP_PROCESS_ERROR, GetLastError());
+        OutputDebugStringW(L"process_execute: Failed to create process");
+        return true; // Not a fatal error
+    }
+
+    if(!send_control(hComm, RESP_PROCESS_START)) {
+        return false;
+    }
+
+    if(!interactive) {
+        // Process started and we don't have to wait
+        // Finish successfully
+        return true;
+    }
+
+    // Message loop
+    OVERLAPPED opStdin = {0};
+    OVERLAPPED opStdout = {0};
+    OVERLAPPED opStderr = {0};
+
+    BOOL stdinPending = false;
+    BOOL stdoutPending = false;
+    BOOL stderrPending = false;
+
+    DWORD exitCode = 0;
+    DWORD lastError = 0;
+
+    #define LOOP_BREAK_FATAL_ERROR 1
+    #define LOOP_BREAK_BROKEN_PIPE 2
+    #define LOOP_BREAK_PROCESS_EXIT 3
+    #define LOOP_BREAK_KILL_PROCESS 4
+    #define LOOP_BREAK_BAD_REQUEST 5
+
+    DWORD loopBreakReason = 0;
+
+    opStdin.hEvent = CreateEvent(NULL, true, true, NULL);
+    opStdout.hEvent = CreateEvent(NULL, true, true, NULL);
+    opStderr.hEvent = CreateEvent(NULL, true, true, NULL);
+
+    control = 0;
+
+    while(true) {
+        /**
+         * Loop that is waiting for the following signals:
+         *
+         * 0 - Process termination
+         * 1 - Input from drakshell client
+         *     - stdin
+         *     - termination request
+         * 2 - Stdout from process
+         * 3 - Stderr from process
+         */
+        HANDLE waitable_handles[4] = {
+            hProcess, opStdin.hEvent, opStdout.hEvent, opStderr.hEvent
+        };
+        DWORD status = WaitForMultipleObjects(
+            4, waitable_handles, false, 50
+        );
+        if (status == 0) {
+            // Process is terminated
+            // Close everything and report the exit code
+            OutputDebugStringW(L"process_execute: hProcess signalled");
+            if(!GetExitCodeProcess(hProcess, &exitCode)) {
+                OutputDebugStringW(L"process_execute: Process exited but can't get exit code");
+                lastError = GetLastError();
+                loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                break;
+            } else {
+                loopBreakReason = LOOP_BREAK_PROCESS_EXIT;
+            }
+            CloseHandle(hProcess);
+            hProcess = INVALID_HANDLE_VALUE;
+            break;
+        }
+        else if(status == 1) {
+            // stdin packet from drakshell client
+            OutputDebugStringW(L"process_execute: stdin signalled");
+            DWORD bytesRead = 0;
+            DWORD bytesWritten = 0;
+            if(stdinPending) {
+                OutputDebugStringW(L"process_execute: stdin pending");
+                // Pending operation finished
+                // Call GetOverlappedResult to get the size
+                // Then send the stdin to the process
+                if(!GetOverlappedResult(hComm, &opStdin, &bytesRead, false)) {
+                    // ERR: Operation is still pending? Weird...
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdin read broken pipe");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+                // Async stdin read only reads control byte
+                if(control == REQ_DATA) {
+                    if(!recv_data(hComm, buffers.stdinBuffer, (LPWORD)&bytesRead, sizeof(buffers.stdinBuffer))) {
+                        // ERR: Failed to read block
+                        lastError = GetLastError();
+                        OutputDebugStringW(L"process_execute: stdin read failed");
+                        loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                        break;
+                    }
+                    if(!sendn(
+                        std_handles.hStdinWrite, buffers.stdinBuffer, bytesRead
+                    )) {
+                        // ERR: Failed to write to stdin
+                        lastError = GetLastError();
+                        OutputDebugStringW(L"process_execute: stdin write failed");
+                        loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                        break;
+                    }
+                }
+                else if(control == REQ_TERMINATE_PROCESS) {
+                    // Terminate gracefully
+                    loopBreakReason = LOOP_BREAK_KILL_PROCESS;
+                    break;
+                }
+                else {
+                    // Unknown control
+                    loopBreakReason = LOOP_BREAK_BAD_REQUEST;
+                    break;
+                }
+            }
+            if(!ReadFile(hComm, &control, 1, NULL, &opStdin)) {
+                if(GetLastError() == ERROR_IO_PENDING) {
+                    stdinPending = true;
+                } else {
+                    // ERROR: Read failed
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdin read failed");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+            } else {
+                OutputDebugStringW(L"process_execute: got stdin immediately");
+                stdinPending = true;
+            }
+            OutputDebugStringW(L"process_execute: stdin handled");
+        }
+        else if (status == 2) {
+            OutputDebugStringW(L"process_execute: stdout signalled");
+            DWORD bytesRead = 0;
+            DWORD bytesWritten = 0;
+            // stdout packet from process
+            if(stdoutPending) {
+                OutputDebugStringW(L"process_execute: stdout pending");
+                // Pending operation finished
+                // Call GetOverlappedResult to get the size
+                // Then send the stdout to the client
+                if(!GetOverlappedResult(std_handles.hStdoutRead, &opStdout, &bytesRead, false)) {
+                    // ERR: Operation is still pending? Weird...
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdout read broken pipe");
+                    loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                    break;
+                }
+                if(!send_control(hComm, RESP_STDOUT_DATA)) {
+                    // ERR: Failed to send control byte
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdout write failed");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+                if(!send_data(hComm, buffers.stdoutBuffer, (WORD)bytesRead)) {
+                    // ERR: Failed to send block
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdout write failed");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+            }
+            if(!ReadFile(std_handles.hStdoutRead, buffers.stdoutBuffer, sizeof(buffers.stdoutBuffer), NULL, &opStdout)) {
+                if(GetLastError() == ERROR_IO_PENDING) {
+                    stdoutPending = true;
+                } else {
+                    // ERROR: Read failed
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stdout read failed");
+                    loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                    break;
+                }
+            } else {
+                // Result was immediately available
+                // I hope the object is signaled in that case
+                // and we can just handle it in another loop
+                OutputDebugStringW(L"process_execute: got stdout immediately");
+                stdoutPending = true;
+            }
+            OutputDebugStringW(L"process_execute: stdout handled");
+        }
+        else if (status == 3) {
+            OutputDebugStringW(L"process_execute: stderr signalled");
+            DWORD bytesRead = 0;
+            DWORD bytesWritten = 0;
+            // stderr packet from process
+            if(stderrPending) {
+                OutputDebugStringW(L"process_execute: stderr pending");
+                // Pending operation finished
+                // Call GetOverlappedResult to get the size
+                // Then send the stderr to the client
+                if(!GetOverlappedResult(std_handles.hStderrRead, &opStderr, &bytesRead, false)) {
+                    // ERR: Operation is still pending? Weird...
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stderr read broken pipe");
+                    loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                    break;
+                }
+                if(!send_control(hComm, RESP_STDERR_DATA)) {
+                    // ERR: Failed to send control byte
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stderr write failed");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+                if(!send_data(hComm, buffers.stderrBuffer, (WORD)bytesRead)) {
+                    // ERR: Failed to send block
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stderr write failed");
+                    loopBreakReason = LOOP_BREAK_FATAL_ERROR;
+                    break;
+                }
+            }
+            if(!ReadFile(std_handles.hStderrRead, buffers.stderrBuffer, sizeof(buffers.stderrBuffer), NULL, &opStderr)) {
+                if(GetLastError() == ERROR_IO_PENDING) {
+                    stderrPending = true;
+                } else {
+                    // ERROR: Read failed
+                    lastError = GetLastError();
+                    OutputDebugStringW(L"process_execute: stderr read failed");
+                    loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+                    break;
+                }
+            } else {
+                // Result was immediately available
+                // I hope the object is signaled in that case
+                // and we can just handle it in another loop
+                stderrPending = true;
+                OutputDebugStringW(L"process_execute: got stderr immediately");
+            }
+            OutputDebugStringW(L"process_execute: stderr handled");
+        }
+        else if (status == WAIT_TIMEOUT) {
+            continue;
+        }
+        else {
+            // something went wrong
+            // Terminate process, close everything and report the fatal error
+            lastError = GetLastError();
+            OutputDebugStringW(L"process_execute: WaitForMultipleObjects unexpected status");
+            loopBreakReason = LOOP_BREAK_BROKEN_PIPE;
+            break;
+        }
+    }
+
+    if(hProcess != INVALID_HANDLE_VALUE) {
+        // Process is not terminated or it has unknown status
+        if(LOOP_BREAK_BROKEN_PIPE == loopBreakReason ||
+           LOOP_BREAK_PROCESS_EXIT == loopBreakReason)
+        {
+            // Wait a while for process to stop
+            WaitForSingleObject(hProcess, 1000);
+        }
+        if(!GetExitCodeProcess(hProcess, &exitCode))
+        {
+            // Process is not yet closed, needs to be terminated
+            OutputDebugStringW(L"process_execute: terminating process with ERROR_BROKEN_PIPE");
+            TerminateProcess(hProcess, ERROR_BROKEN_PIPE);
+            exitCode = ERROR_BROKEN_PIPE;
+        }
+        CloseHandle(hProcess);
+        hProcess = INVALID_HANDLE_VALUE;
+    }
+
+    if(stdinPending) {
+        CancelIo(hComm);
+    }
+    if(stdoutPending) {
+        CancelIo(std_handles.hStdoutRead);
+    }
+    if(stderrPending) {
+        CancelIo(std_handles.hStderrRead);
+    }
+    close_std_handles(&std_handles);
+
+    CloseHandle(opStdin.hEvent);
+    CloseHandle(opStdout.hEvent);
+    CloseHandle(opStderr.hEvent);
+
+    if(LOOP_BREAK_FATAL_ERROR == loopBreakReason) {
+        send_fatal_error(hComm, lastError);
+        OutputDebugStringW(L"interactive_execute: fatal error");
+        return false;
+    }
+    else if(LOOP_BREAK_BROKEN_PIPE == loopBreakReason ||
+            LOOP_BREAK_PROCESS_EXIT == loopBreakReason ||
+            LOOP_BREAK_KILL_PROCESS == loopBreakReason ||
+            LOOP_BREAK_BAD_REQUEST == loopBreakReason)
+    {
+        // Report process exit
+        send_control_with_code(hComm, RESP_PROCESS_EXIT, exitCode);
+        OutputDebugStringW(L"interactive_execute: finished successfully");
+        return true;
+    }
+}
+
+static bool send_info(HANDLE hComm) {
+    DWORD pid = GetCurrentProcessId();
+    DWORD tid = GetCurrentThreadId();
+    if(!sendn(hComm, (LPBYTE)&pid, sizeof(pid))) {
+        return false;
+    }
+    if(!sendn(hComm, (LPBYTE)&tid, sizeof(tid))) {
+        return false;
+    }
+    return true;
+}
+
+void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
+    DCB dcb = { .DCBlength = sizeof(DCB) };
+
+    if(!load_winapi()) {
+        // Failed to load some WinAPI functions
+        return;
+    }
+
+    Sleep(500); // Some sleep to let injector finish his job
+
+    OutputDebugStringW(L"Hello from drakshell");
+
+    HANDLE hComm = CreateFileW(
+        L"\\\\.\\COM1",
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if(hComm == INVALID_HANDLE_VALUE)
+    {
+        OutputDebugStringW(L"Failed to connect to COM1");
+        return;
+    }
+
+    if(!BuildCommDCB("baud=115200 parity=N data=8 stop=1", &dcb))
+    {
+        OutputDebugStringW(L"Failed to get DCB for COM1");
+        return;
+    }
+
+    if(!SetCommState(hComm, &dcb))
+    {
+        OutputDebugStringW(L"Failed to set mode of COM1");
+        return;
+    }
+
+    OutputDebugStringW(L"Connected to COM1");
+
+    while(true) {
+        BYTE control = 0;
+        if(!recv_control(hComm, &control)) {
+            OutputDebugStringW(L"Failed to receive request control byte");
+            break;
+        }
+        if(control == REQ_PING) {
+            // Ping checks if shell is in initial state
+            // and is able to receive commands
+            if(!send_control(hComm, RESP_PONG)) {
+                OutputDebugStringW(L"Failed to send RESP_PONG response");
+                break;
+            }
+        }
+        else if(control == REQ_GET_INFO) {
+            if(!send_control(hComm, RESP_INFO)) {
+                OutputDebugStringW(L"Failed to send RESP_INFO response");
+                break;
+            }
+            if(!send_info(hComm)) {
+                OutputDebugStringW(L"Failed to send INFO response");
+                break;
+            }
+        }
+        else if(control == REQ_INTERACTIVE_EXECUTE) {
+            if(!send_control(hComm, RESP_INTERACTIVE_EXECUTE_START)) {
+                OutputDebugStringW(L"Failed to send RESP_INTERACTIVE_EXECUTE_START response");
+                break;
+            }
+            if(!process_execute(hComm, true)) {
+                OutputDebugStringW(L"Fatal error in interactive execute mode");
+                break;
+            }
+        }
+        else if(control == REQ_NON_INTERACTIVE_EXECUTE) {
+            if(!send_control(hComm, RESP_NON_INTERACTIVE_EXECUTE_START)) {
+                OutputDebugStringW(L"Failed to send RESP_INTERACTIVE_EXECUTE_START response");
+                break;
+            }
+            if(!process_execute(hComm, false)) {
+                OutputDebugStringW(L"Fatal error in non-interactive execute mode");
+                break;
+            }
+        }
+        else if(control == REQ_EXECUTE_AND_FINISH) {
+            if(!send_control(hComm, RESP_EXECUTE_AND_FINISH_START)) {
+                OutputDebugStringW(L"Failed to send RESP_INTERACTIVE_EXECUTE_START response");
+                break;
+            }
+            if(!process_execute(hComm, false)) {
+                OutputDebugStringW(L"Fatal error in execute-and-finish mode");
+            }
+            // We're always finishing here
+            break;
+        }
+        else if(control == REQ_FINISH) {
+            if(!send_control(hComm, RESP_FINISH_START)) {
+                OutputDebugStringW(L"Failed to send RESP_FINISH_START response");
+            }
+            break;
+        }
+        else if(control == REQ_DATA) {
+            // We're definitely out of sync, but we need to consume
+            // what client wants to serve
+            if(!recv_data_to_void(hComm)) {
+                OutputDebugStringW(L"Failed to receive REQ_DATA");
+                break;
+            }
+            if(!send_control(hComm, RESP_BAD_REQ)) {
+                OutputDebugStringW(L"Failed to send RESP_BAD_REQ response");
+                break;
+            }
+        }
+        else {
+            if(!send_control(hComm, RESP_BAD_REQ)) {
+                OutputDebugStringW(L"Failed to send RESP_BAD_REQ response");
+                break;
+            }
+        }
+    }
+    OutputDebugStringW(L"Bye");
+    CloseHandle(hComm);
+}
+
+extern void thread_start();
+
+// Tell the compiler incoming stack alignment is not RSP%16==8 or ESP%16==12
+__attribute__((force_align_arg_pointer))
+__attribute__((section(".startup")))
+void _start() {
+    // Escape from hijacked thread to the dedicated thread ASAP
+    // This will cause injector to recover the original thread
+    // and make possible to do any long-term actions without interfering
+    // with explorer.exe operations
+
+    // Universal get_pc_thunk for further cleanup
+    // _start will be for sure somewhere on the first page
+    // of injected code allocation
+    volatile void* base_ptr;
+    asm("call _next\n\t"
+        "_next: pop %0": "=r"(base_ptr));
+
+    PCreateThread pCreateThread = get_func_from_peb(L"kernel32.dll", "CreateThread");
+    (*pCreateThread)(
+        NULL, // lpThreadAttributes
+        0,    // dwStackSize
+        thread_start,
+        (void*)base_ptr, // lpParameter
+        0,    // dwCreationFlags
+        NULL // lpThreadId
+    );
+}

--- a/drakrun/drakrun/tools/drakshell/include/nt_loader.h
+++ b/drakrun/drakrun/tools/drakshell/include/nt_loader.h
@@ -1,0 +1,363 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if __SIZEOF_WCHAR_T__ != 2
+#error "wchar_t is not two-byte, please compile with -fshort-wchar"
+#endif
+
+#define GENERIC_WRITE 0x40000000
+#define GENERIC_READ  0x80000000
+#define OPEN_EXISTING 3
+#define CREATE_NEW 1
+#define INVALID_HANDLE_VALUE ((void*)(long long)-1)
+#define HANDLE_FLAG_INHERIT 1
+#define STARTF_USESTDHANDLES 0x00000100
+#define ERROR_IO_PENDING 0x000003e5
+#define ERROR_BROKEN_PIPE 0x0000006d
+#define PIPE_ACCESS_DUPLEX 0x00000003
+#define PIPE_ACCESS_OUTBOUND 0x00000002
+#define PIPE_ACCESS_INBOUND 0x00000001
+#define FILE_FLAG_OVERLAPPED 0x40000000
+#define FILE_FLAG_FIRST_PIPE_INSTANCE 0x00080000
+#define WAIT_TIMEOUT 0x00000102
+#define INFINITE 0xffffffff
+
+typedef uint8_t BYTE;
+typedef uint16_t WORD;
+typedef uint32_t DWORD;
+typedef uint64_t QWORD;
+
+typedef uint8_t * PBYTE, * LPBYTE;
+typedef uint16_t * PWORD, * LPWORD;
+typedef uint32_t * PDWORD, * LPDWORD;
+typedef uint64_t * PQWORD, * LPQWORD;
+
+typedef long LONG;
+typedef unsigned long ULONG;
+typedef int INT;
+typedef unsigned int UINT;
+typedef short SHORT;
+typedef unsigned short USHORT;
+typedef char CHAR;
+typedef unsigned char UCHAR;
+
+typedef void* HANDLE;
+typedef void* PVOID;
+typedef PVOID LPVOID;
+typedef HANDLE *PHANDLE;
+typedef unsigned long SIZE_T;
+typedef const char* LPCSTR;
+typedef const wchar_t* LPCWSTR;
+typedef char* LPSTR;
+typedef wchar_t* LPWSTR;
+typedef bool BOOL;
+
+typedef struct _DCB {
+    DWORD DCBlength;
+    DWORD BaudRate;
+    DWORD fBinary : 1;
+    DWORD fParity : 1;
+    DWORD fOutxCtsFlow : 1;
+    DWORD fOutxDsrFlow : 1;
+    DWORD fDtrControl : 2;
+    DWORD fDsrSensitivity : 1;
+    DWORD fTXContinueOnXoff : 1;
+    DWORD fOutX : 1;
+    DWORD fInX : 1;
+    DWORD fErrorChar : 1;
+    DWORD fNull : 1;
+    DWORD fRtsControl : 2;
+    DWORD fAbortOnError : 1;
+    DWORD fDummy2 : 17;
+    WORD  wReserved;
+    WORD  XonLim;
+    WORD  XoffLim;
+    BYTE  ByteSize;
+    BYTE  Parity;
+    BYTE  StopBits;
+    char  XonChar;
+    char  XoffChar;
+    char  ErrorChar;
+    char  EofChar;
+    char  EvtChar;
+    WORD  wReserved1;
+} DCB, *LPDCB;
+
+typedef struct _SECURITY_ATTRIBUTES {
+    DWORD  nLength;
+    LPVOID lpSecurityDescriptor;
+    BOOL   bInheritHandle;
+} SECURITY_ATTRIBUTES, *PSECURITY_ATTRIBUTES, *LPSECURITY_ATTRIBUTES;
+
+typedef struct _STARTUPINFOW {
+    DWORD  cb;
+    LPWSTR lpReserved;
+    LPWSTR lpDesktop;
+    LPWSTR lpTitle;
+    DWORD  dwX;
+    DWORD  dwY;
+    DWORD  dwXSize;
+    DWORD  dwYSize;
+    DWORD  dwXCountChars;
+    DWORD  dwYCountChars;
+    DWORD  dwFillAttribute;
+    DWORD  dwFlags;
+    WORD   wShowWindow;
+    WORD   cbReserved2;
+    LPBYTE lpReserved2;
+    HANDLE hStdInput;
+    HANDLE hStdOutput;
+    HANDLE hStdError;
+} STARTUPINFOW, *LPSTARTUPINFOW;
+
+typedef struct _PROCESS_INFORMATION {
+    HANDLE hProcess;
+    HANDLE hThread;
+    DWORD  dwProcessId;
+    DWORD  dwThreadId;
+} PROCESS_INFORMATION, *PPROCESS_INFORMATION, *LPPROCESS_INFORMATION;
+
+typedef struct _OVERLAPPED {
+    PVOID Internal;
+    PVOID InternalHigh;
+    union {
+        struct {
+            DWORD Offset;
+            DWORD OffsetHigh;
+        } DUMMYSTRUCTNAME;
+        PVOID Pointer;
+    } DUMMYUNIONNAME;
+    HANDLE    hEvent;
+} OVERLAPPED, *LPOVERLAPPED;
+
+#define WINAPI __attribute__((ms_abi))
+
+typedef int (WINAPI* PCreateThread)(
+    LPVOID lpThreadAttributes,
+    SIZE_T dwStackSize,
+    LPVOID lpStartAddress,
+    LPVOID lpParameter,
+    DWORD dwCreationFlags,
+    LPDWORD lpThreadId
+);
+extern PCreateThread pCreateThread;
+#define CreateThread (*pCreateThread)
+
+typedef HANDLE (WINAPI* PLoadLibraryW)(LPCWSTR lpLibFileName);
+extern PLoadLibraryW pLoadLibraryW;
+#define LoadLibraryW (*pLoadLibraryW)
+
+typedef HANDLE (WINAPI* PGetProcAddress)(HANDLE hModule, LPCSTR lpProcName);
+extern PGetProcAddress pGetProcAddress;
+#define GetProcAddress (*pGetProcAddress)
+
+typedef int (WINAPI* PMessageBoxA)(HANDLE, LPCSTR, LPCSTR, UINT);
+extern PMessageBoxA pMessageBoxA;
+#define MessageBoxA (*pMessageBoxA)
+
+typedef DWORD (WINAPI* PExpandEnvironmentStringsW)(LPCWSTR lpSrc, LPWSTR lpDst, DWORD nSize);
+extern PExpandEnvironmentStringsW pExpandEnvironmentStringsW;
+#define ExpandEnvironmentStringsW (*pExpandEnvironmentStringsW)
+
+typedef void (WINAPI* POutputDebugStringW)(LPCWSTR lpOutputString);
+extern POutputDebugStringW pOutputDebugStringW;
+#define OutputDebugStringW (*pOutputDebugStringW)
+
+typedef bool (WINAPI* PCloseHandle)(HANDLE hObject);
+extern PCloseHandle pCloseHandle;
+#define CloseHandle (*pCloseHandle)
+
+typedef BOOL (WINAPI* PCreateProcessW)(
+    LPCWSTR lpApplicationName,
+    LPWSTR lpCommandLine,
+    LPSECURITY_ATTRIBUTES lpProcessAttributes,
+    LPSECURITY_ATTRIBUTES lpThreadAttributes,
+    BOOL bInheritHandles,
+    DWORD dwCreationFlags,
+    LPVOID lpEnvironment,
+    LPCWSTR lpCurrentDirectory,
+    LPSTARTUPINFOW lpStartupInfo,
+    LPPROCESS_INFORMATION lpProcessInformation
+);
+extern PCreateProcessW pCreateProcessW;
+#define CreateProcessW (*pCreateProcessW)
+
+typedef HANDLE (WINAPI* PCreateFileW)(
+    LPCWSTR lpFileName,
+    DWORD dwDesiredAccess,
+    DWORD dwShareMode,
+    LPVOID lpSecurityAttributes,
+    DWORD dwCreationDisposition,
+    DWORD dwFlagsAndAttributes,
+    HANDLE hTemplateFile
+);
+extern PCreateFileW pCreateFileW;
+#define CreateFileW (*pCreateFileW)
+
+typedef bool (WINAPI* PReadFile)(
+    HANDLE hFile,
+    LPVOID lpBuffer,
+    DWORD nNumberOfBytesToRead,
+    LPDWORD lpNumberOfBytesRead,
+    LPVOID lpOverlapped
+);
+extern PReadFile pReadFile;
+#define ReadFile (*pReadFile)
+
+typedef bool (WINAPI* PWriteFile)(
+    HANDLE hFile,
+    LPVOID lpBuffer,
+    DWORD nNumberOfBytesToWrite,
+    LPDWORD lpNumberOfBytesWritten,
+    LPVOID lpOverlapped
+);
+extern PWriteFile pWriteFile;
+#define WriteFile (*pWriteFile)
+
+typedef void (WINAPI* PExitThread)(
+    DWORD dwExitCode
+);
+extern PExitThread pExitThread;
+#define ExitThread (*pExitThread)
+
+typedef void (WINAPI* PSleep)(
+    DWORD dwMilliseconds
+);
+extern PSleep pSleep;
+#define Sleep (*pSleep)
+
+typedef void (WINAPI* PVirtualFree)(
+    LPVOID lpAddress,
+    SIZE_T dwSize,
+    DWORD  dwFreeType
+);
+extern PVirtualFree pVirtualFree;
+
+typedef DWORD (WINAPI* PGetLastError)();
+extern PGetLastError pGetLastError;
+#define GetLastError (*pGetLastError)
+
+typedef BOOL (WINAPI* PGetCommState)(
+    HANDLE hFile,
+    LPDCB  lpDCB
+);
+extern PGetCommState pGetCommState;
+#define GetCommState (*pGetCommState)
+
+typedef BOOL (WINAPI* PSetCommState)(
+    HANDLE hFile,
+    LPDCB  lpDCB
+);
+extern PSetCommState pSetCommState;
+#define SetCommState (*pSetCommState)
+
+typedef BOOL (WINAPI* PCreatePipe)(
+    PHANDLE hReadPipe,
+    PHANDLE hWritePipe,
+    LPSECURITY_ATTRIBUTES lpPipeAttributes,
+    DWORD nSize
+);
+extern PCreatePipe pCreatePipe;
+#define CreatePipe (*pCreatePipe)
+
+typedef BOOL (WINAPI* PSetHandleInformation)(
+    HANDLE hObject,
+    DWORD  dwMask,
+    DWORD  dwFlags
+);
+extern PSetHandleInformation pSetHandleInformation;
+#define SetHandleInformation (*pSetHandleInformation)
+
+typedef DWORD (WINAPI* PWaitForMultipleObjects)(
+    DWORD nCount,
+    const HANDLE *lpHandles,
+    BOOL bWaitAll,
+    DWORD dwMilliseconds
+);
+extern PWaitForMultipleObjects pWaitForMultipleObjects;
+#define WaitForMultipleObjects (*pWaitForMultipleObjects)
+
+typedef HANDLE (WINAPI* PCreateEvent)(
+    LPSECURITY_ATTRIBUTES lpEventAttributes,
+    BOOL bManualReset,
+    BOOL bInitialState,
+    LPCSTR lpName
+);
+extern PCreateEvent pCreateEvent;
+#define CreateEvent (*pCreateEvent)
+
+typedef BOOL (WINAPI* PGetOverlappedResult)(
+    HANDLE hFile,
+    LPOVERLAPPED lpOverlapped,
+    LPDWORD lpNumberOfBytesTransferred,
+    BOOL bWait
+);
+extern PGetOverlappedResult pGetOverlappedResult;
+#define GetOverlappedResult (*pGetOverlappedResult)
+
+typedef BOOL (WINAPI* PCancelIo)(
+    HANDLE hFile
+);
+extern PCancelIo pCancelIo;
+#define CancelIo (*pCancelIo)
+
+typedef BOOL (WINAPI* PGetExitCodeProcess)(
+    HANDLE hProcess,
+    LPDWORD lpExitCode
+);
+extern PGetExitCodeProcess pGetExitCodeProcess;
+#define GetExitCodeProcess (*pGetExitCodeProcess)
+
+typedef BOOL (WINAPI* PTerminateProcess)(
+    HANDLE hProcess,
+    UINT uExitCode
+);
+extern PTerminateProcess pTerminateProcess;
+#define TerminateProcess (*pTerminateProcess)
+
+typedef HANDLE (WINAPI* PCreateNamedPipeW)(
+    LPCWSTR lpName,
+    DWORD dwOpenMode,
+    DWORD dwPipeMode,
+    DWORD nMaxInstances,
+    DWORD nOutBufferSize,
+    DWORD nInBufferSize,
+    DWORD nDefaultTimeOut,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes
+);
+extern PCreateNamedPipeW pCreateNamedPipeW;
+#define CreateNamedPipe (*pCreateNamedPipeW)
+
+typedef DWORD (WINAPI* PWaitForSingleObject)(
+    HANDLE hHandle,
+    DWORD  dwMilliseconds
+);
+extern PWaitForSingleObject pWaitForSingleObject;
+#define WaitForSingleObject (*pWaitForSingleObject)
+
+typedef void (WINAPI* PSetLastError)(
+    DWORD dwErrCode
+);
+extern PSetLastError pSetLastError;
+#define SetLastError (*pSetLastError)
+
+typedef DWORD (WINAPI *PGetCurrentProcessId)();
+extern PGetCurrentProcessId pGetCurrentProcessId;
+#define GetCurrentProcessId (*pGetCurrentProcessId)
+
+typedef DWORD (WINAPI *PGetCurrentThreadId)();
+extern PGetCurrentThreadId pGetCurrentThreadId;
+#define GetCurrentThreadId (*pGetCurrentThreadId)
+
+typedef BOOL (WINAPI *PBuildCommDCB)(
+     LPCSTR lpDef,
+     LPDCB  lpDCB
+);
+extern PBuildCommDCB pBuildCommDCB;
+#define BuildCommDCB (*pBuildCommDCB)
+
+extern void* get_func_from_peb(const wchar_t* libraryName, const char* procName);
+extern bool load_winapi();

--- a/drakrun/drakrun/tools/drakshell/linker.ld
+++ b/drakrun/drakrun/tools/drakshell/linker.ld
@@ -1,0 +1,37 @@
+ENTRY(_start)
+
+PHDRS {
+    text PT_LOAD FLAGS(7);   /* R-X */
+}
+SECTIONS
+{
+    .text : SUBALIGN(16)
+    {
+        *(.startup)
+        *(.text)
+        *(.text.*)
+        *(.data)
+        *(.data.*)
+        *(.rodata)
+        *(.rodata.*)
+    } :text
+
+    .bss : SUBALIGN(16)
+    {
+        bss_start = .;
+        *(.bss)
+        *(.bss.*)
+        bss_end = .;
+    }
+
+    /DISCARD/ : {
+        *(.comment)
+        *(.dynsym)
+        *(.dynstr)
+        *(.gnu.hash)
+        *(.hash)
+        *(.eh_frame_hdr)
+        *(.eh_frame)
+        *(.dynamic)
+    }
+}

--- a/drakrun/drakrun/tools/drakshell/nt_loader.c
+++ b/drakrun/drakrun/tools/drakshell/nt_loader.c
@@ -1,0 +1,281 @@
+#include "nt_loader.h"
+
+typedef struct _LIST_ENTRY {
+    struct _LIST_ENTRY *Flink;
+    struct _LIST_ENTRY *Blink;
+} LIST_ENTRY, *PLIST_ENTRY;
+
+typedef struct _PEB_LDR_DATA {
+    uint8_t Reserved1[8];
+    void* Reserved2[2];
+    LIST_ENTRY InLoadOrderModuleList;
+    LIST_ENTRY InMemoryOrderModuleList;
+    LIST_ENTRY InInitOrderModuleList;
+} PEB_LDR_DATA, *PPEB_LDR_DATA;
+
+typedef struct _PEB {
+    uint8_t Reserved1[2];
+    uint8_t BeingDebugged;
+    uint8_t Reserved2[1];
+    void* Reserved3[2];
+    PPEB_LDR_DATA Ldr;
+} PEB, *PPEB;
+
+typedef struct _UNICODE_STRING
+{
+    uint16_t Length;
+    uint16_t MaximumLength;
+    wchar_t* Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _LDR_DATA_TABLE_ENTRY {
+    LIST_ENTRY InLoadOrderLinks;
+    LIST_ENTRY InMemoryOrderLinks;
+    LIST_ENTRY InInitOrderModuleList;
+    void* DllBase;
+    void* EntryPoint;
+    void* Reserved3;
+    UNICODE_STRING FullDllName;
+    UNICODE_STRING BaseDllName;
+} LDR_DATA_TABLE_ENTRY, *PLDR_DATA_TABLE_ENTRY;
+
+typedef struct _IMAGE_DOS_HEADER
+{
+    uint16_t e_magic;
+    uint16_t e_cblp;
+    uint16_t e_cp;
+    uint16_t e_crlc;
+    uint16_t e_cparhdr;
+    uint16_t e_minalloc;
+    uint16_t e_maxalloc;
+    uint16_t e_ss;
+    uint16_t e_sp;
+    uint16_t e_csum;
+    uint16_t e_ip;
+    uint16_t e_cs;
+    uint16_t e_lfarlc;
+    uint16_t e_ovno;
+    uint16_t e_res[4];
+    uint16_t e_oemid;
+    uint16_t e_oeminfo;
+    uint16_t e_res2[10];
+    uint32_t e_lfanew;
+} IMAGE_DOS_HEADER, *PIMAGE_DOS_HEADER;
+
+typedef struct _IMAGE_FILE_HEADER {
+    uint16_t Machine;
+    uint16_t NumberOfSections;
+    uint32_t TimeDateStamp;
+    uint32_t PointerToSymbolTable;
+    uint32_t NumberOfSymbols;
+    uint16_t SizeOfOptionalHeader;
+    uint16_t Characteristics;
+} IMAGE_FILE_HEADER, *PIMAGE_FILE_HEADER;
+
+typedef struct _IMAGE_DATA_DIRECTORY {
+    uint32_t VirtualAddress;
+    uint32_t Size;
+} IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+
+typedef struct _IMAGE_OPTIONAL_HEADER {
+    uint16_t Magic;
+    uint8_t MajorLinkerVersion;
+    uint8_t MinorLinkerVersion;
+    uint32_t SizeOfCode;
+    uint32_t SizeOfInitializedData;
+    uint32_t SizeOfUninitializedData;
+    uint32_t AddressOfEntryPoint;
+    uint32_t BaseOfCode;
+    void* ImageBase;
+    uint32_t SectionAlignment;
+    uint32_t FileAlignment;
+    uint16_t MajorOperatingSystemVersion;
+    uint16_t MinorOperatingSystemVersion;
+    uint16_t MajorImageVersion;
+    uint16_t MinorImageVersion;
+    uint16_t MajorSubsystemVersion;
+    uint16_t MinorSubsystemVersion;
+    uint32_t Win32VersionValue;
+    uint32_t SizeOfImage;
+    uint32_t SizeOfHeaders;
+    uint32_t CheckSum;
+    uint16_t Subsystem;
+    uint16_t DllCharacteristics;
+    void* SizeOfStackReserve;
+    void* SizeOfStackCommit;
+    void* SizeOfHeapReserve;
+    void* SizeOfHeapCommit;
+    uint32_t LoaderFlags;
+    uint32_t NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[16];
+} IMAGE_OPTIONAL_HEADER, *PIMAGE_OPTIONAL_HEADER;
+
+typedef struct _IMAGE_NT_HEADERS {
+    uint32_t Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER OptionalHeader;
+} IMAGE_NT_HEADERS, *PIMAGE_NT_HEADERS;
+
+#define IMAGE_DIRECTORY_ENTRY_EXPORT 0
+
+typedef struct _IMAGE_EXPORT_DIRECTORY {
+     uint32_t Characteristics;
+     uint32_t TimeDateStamp;
+     uint16_t MajorVersion;
+     uint16_t MinorVersion;
+     uint32_t Name;
+     uint32_t Base;
+     uint32_t NumberOfFunctions;
+     uint32_t NumberOfNames;
+     uint32_t AddressOfFunctions;
+     uint32_t AddressOfNames;
+     uint32_t AddressOfNameOrdinals;
+ } IMAGE_EXPORT_DIRECTORY, *PIMAGE_EXPORT_DIRECTORY;
+
+#define container_of(ptr, type, member) ({ \
+                const typeof( ((type *)0)->member ) *__mptr = (ptr); \
+                (type *)( (char *)__mptr - offsetof(type, member) );})
+
+static PPEB get_peb() {
+    volatile PPEB peb;
+    #if defined(__x86_64__)
+        asm("mov %0, gs:[0x60]" : "=r"(peb));
+    #endif
+    #if defined(__i386__)
+        asm("mov %0, fs:[0x30]" : "=r"(peb));
+    #endif
+    return peb;
+}
+
+static wchar_t lowercase(wchar_t c) {
+    return (c >='A' && c <= 'Z') ? c - 'A' + 'a' : c;
+}
+
+static bool unicode_string_equals(PUNICODE_STRING unicodeString, const wchar_t* value) {
+    uint16_t current_length = unicodeString->Length / 2; // without null-byte
+    wchar_t* current_char = unicodeString->Buffer;
+    while(current_length > 0 && *value != 0) {
+        if(lowercase(*value) != lowercase(*current_char))
+            return false;
+        value++;
+        current_char++;
+        current_length--;
+    }
+    return current_length == 0 && *value == 0;
+}
+
+static int strcmp(const char* s1, const char* s2)
+{
+    while(*s1 && (*s1 == *s2))
+    {
+        s1++;
+        s2++;
+    }
+    return *(const unsigned char*)s1 - *(const unsigned char*)s2;
+}
+
+void* get_func_from_peb(const wchar_t* libraryName, const char* procName)
+{
+    PPEB peb = get_peb();
+    PLIST_ENTRY module_entry = peb->Ldr->InMemoryOrderModuleList.Flink;
+    while(module_entry) {
+        PLDR_DATA_TABLE_ENTRY module = container_of(module_entry, LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
+        if(unicode_string_equals(&module->BaseDllName, libraryName))
+        {
+            void* DllBase = module->DllBase;
+            PIMAGE_NT_HEADERS pDLL = DllBase + ((PIMAGE_DOS_HEADER)module->DllBase)->e_lfanew;
+            uint32_t exportsRVA = pDLL->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+            PIMAGE_EXPORT_DIRECTORY exportsDir = DllBase + exportsRVA;
+            uint32_t* names_rva_array = (uint32_t*) (DllBase + exportsDir->AddressOfNames);
+            uint32_t* function_rva_array = (uint32_t*) (DllBase + exportsDir->AddressOfFunctions);
+            uint16_t* name_ordinals_array = (uint16_t*) (DllBase + exportsDir->AddressOfNameOrdinals);
+            for(int i=0; i<exportsDir->NumberOfFunctions; ++i) {
+                char* funct_name = DllBase + names_rva_array[i];
+                uint32_t exported_RVA = function_rva_array[name_ordinals_array[i]];
+
+                if(!strcmp(procName, funct_name)) {
+                    return (void*) (DllBase + exported_RVA);
+                }
+            }
+            return NULL;
+        }
+        module_entry = module_entry->Flink;
+    }
+    return NULL;
+}
+
+PLoadLibraryW pLoadLibraryW;
+PGetProcAddress pGetProcAddress;
+PMessageBoxA pMessageBoxA;
+PExpandEnvironmentStringsW pExpandEnvironmentStringsW;
+POutputDebugStringW pOutputDebugStringW;
+PCloseHandle pCloseHandle;
+PCreateFileW pCreateFileW;
+PReadFile pReadFile;
+PWriteFile pWriteFile;
+PCreateProcessW pCreateProcessW;
+PExitThread pExitThread;
+PSleep pSleep;
+PVirtualFree pVirtualFree;
+PGetLastError pGetLastError;
+PGetCommState pGetCommState;
+PSetCommState pSetCommState;
+PCreatePipe pCreatePipe;
+PSetHandleInformation pSetHandleInformation;
+PWaitForMultipleObjects pWaitForMultipleObjects;
+PCreateEvent pCreateEvent;
+PGetOverlappedResult pGetOverlappedResult;
+PCancelIo pCancelIo;
+PGetExitCodeProcess pGetExitCodeProcess;
+PTerminateProcess pTerminateProcess;
+PCreateNamedPipeW pCreateNamedPipeW;
+PWaitForSingleObject pWaitForSingleObject;
+PSetLastError pSetLastError;
+PGetCurrentProcessId pGetCurrentProcessId;
+PGetCurrentThreadId pGetCurrentThreadId;
+PBuildCommDCB pBuildCommDCB;
+
+bool load_winapi() {
+    HANDLE hKernel32, hUser32;
+
+    pLoadLibraryW = get_func_from_peb(L"kernel32.dll", "LoadLibraryW");
+    pGetProcAddress = get_func_from_peb(L"kernel32.dll", "GetProcAddress");
+    if(!pLoadLibraryW || !pGetProcAddress) {
+        // Failed to find initial functions
+        return false;
+    }
+
+    hKernel32 = LoadLibraryW(L"kernel32.dll");
+    hUser32 = LoadLibraryW(L"user32.dll");
+
+    pMessageBoxA = GetProcAddress(hUser32, "MessageBoxA");
+    pExpandEnvironmentStringsW = GetProcAddress(hKernel32, "ExpandEnvironmentStringsW");
+    pOutputDebugStringW = GetProcAddress(hKernel32, "OutputDebugStringW");
+    pCloseHandle = GetProcAddress(hKernel32, "CloseHandle");
+    pCreateFileW = GetProcAddress(hKernel32, "CreateFileW");
+    pReadFile = GetProcAddress(hKernel32, "ReadFile");
+    pWriteFile = GetProcAddress(hKernel32, "WriteFile");
+    pCreateProcessW = GetProcAddress(hKernel32, "CreateProcessW");
+    pExitThread = GetProcAddress(hKernel32, "ExitThread");
+    pSleep = GetProcAddress(hKernel32, "Sleep");
+    pVirtualFree = GetProcAddress(hKernel32, "VirtualFree");
+    pGetLastError = GetProcAddress(hKernel32, "GetLastError");
+    pGetCommState = GetProcAddress(hKernel32, "GetCommState");
+    pSetCommState = GetProcAddress(hKernel32, "SetCommState");
+    pCreatePipe = GetProcAddress(hKernel32, "CreatePipe");
+    pSetHandleInformation = GetProcAddress(hKernel32, "SetHandleInformation");
+    pWaitForMultipleObjects = GetProcAddress(hKernel32, "WaitForMultipleObjects");
+    pCreateEvent = GetProcAddress(hKernel32, "CreateEventA");
+    pGetOverlappedResult = GetProcAddress(hKernel32, "GetOverlappedResult");
+    pCancelIo = GetProcAddress(hKernel32, "CancelIo");
+    pGetExitCodeProcess = GetProcAddress(hKernel32, "GetExitCodeProcess");
+    pTerminateProcess = GetProcAddress(hKernel32, "TerminateProcess");
+    pCreateNamedPipeW = GetProcAddress(hKernel32, "CreateNamedPipeW");
+    pWaitForSingleObject = GetProcAddress(hKernel32, "WaitForSingleObject");
+    pSetLastError = GetProcAddress(hKernel32, "SetLastError");
+    pGetCurrentProcessId = GetProcAddress(hKernel32, "GetCurrentProcessId");
+    pGetCurrentThreadId = GetProcAddress(hKernel32, "GetCurrentThreadId");
+    pBuildCommDCB = GetProcAddress(hKernel32, "BuildCommDCBA");
+
+    return true;
+}

--- a/drakrun/drakrun/tools/drakshell/thread_start.S
+++ b/drakrun/drakrun/tools/drakshell/thread_start.S
@@ -1,0 +1,30 @@
+.intel_syntax noprefix
+.globl thread_start
+thread_start:
+
+#if defined(__x86_64__)
+    push rcx
+#endif
+#if defined(__i386__)
+    push ecx
+#endif
+    call drakshell_main
+    # This one is going to deallocate memory occupied by shellcode
+    # and finish the thread to cover up all traces of drakshell
+    # in explorer.exe
+    #
+    # We're going to jump to the VirtualFree and it is going to
+    # return to the ExitThread for us.
+#if defined(__x86_64__)
+    pop rcx
+    and rcx, -4096
+    xor rdx, rdx
+    mov r8, 0x8000
+    jmp [rip+pVirtualFree]
+#endif
+#if defined(__i386__)
+    # TODO: Deallocation for i386 not implemented
+    pop ecx
+    xor eax, eax
+    ret
+#endif


### PR DESCRIPTION
Reintroduced the idea from https://github.com/CERT-Polska/drakvuf-sandbox/pull/945

It assists the injector by providing a well-known looping thread inside explorer.exe that would be a good target for hijacking and injection. The thread will be periodically woke up due to short timeout on blocking operations and will report its TID over the communication channel with the host, so it can be identified.

Another nice feature is that it allows to execute provisioning commands interactively. I have added `draksetup drakshell` command that allows to run a cmd.exe/powershell.exe command (actually any basic console tool would work)