### PR TITLE
draksetup: add 'make-profile' and reorder commands

### DIFF
--- a/drakrun/drakrun/draksetup/main.py
+++ b/drakrun/drakrun/draksetup/main.py
@@ -7,6 +7,7 @@ from .drakshell import drakshell
 from .drakvuf_cmdline import drakvuf_cmdline
 from .injector import injector
 from .install import install
+from .make_profile import make_profile
 from .modify_vm0 import modify_vm0
 from .mount import mount
 from .postinstall import postinstall
@@ -25,13 +26,13 @@ def main():
         logging.error("You need to have root privileges to run this command.")
         raise click.Abort()
 
-
-main.add_command(drakshell)
-main.add_command(drakvuf_cmdline)
 main.add_command(install)
 main.add_command(postinstall)
 main.add_command(vm_start)
 main.add_command(vm_stop)
-main.add_command(mount)
 main.add_command(modify_vm0)
 main.add_command(injector)
+main.add_command(drakshell)
+main.add_command(drakvuf_cmdline)
+main.add_command(mount)
+main.add_command(make_profile)

--- a/drakrun/drakrun/draksetup/main.py
+++ b/drakrun/drakrun/draksetup/main.py
@@ -26,6 +26,7 @@ def main():
         logging.error("You need to have root privileges to run this command.")
         raise click.Abort()
 
+
 main.add_command(install)
 main.add_command(postinstall)
 main.add_command(vm_start)

--- a/drakrun/drakrun/draksetup/make_profile.py
+++ b/drakrun/drakrun/draksetup/make_profile.py
@@ -1,0 +1,62 @@
+import logging
+
+import click
+
+from drakrun.lib.drakshell import Drakshell
+from drakrun.lib.install_info import InstallInfo
+from drakrun.lib.network_info import NetworkConfiguration
+from drakrun.lib.paths import INSTALL_INFO_PATH, NETWORK_CONF_PATH, VMI_INFO_PATH
+from drakrun.lib.vm import VirtualMachine
+from drakrun.lib.vmi_profile import create_vmi_info, create_vmi_json_profile
+
+log = logging.getLogger(__name__)
+
+
+@click.command(help="Make VMI profile")
+@click.option(
+    "--vm-id",
+    "vm_id",
+    default=1,
+    type=int,
+    show_default=True,
+    help="VM id to use for generating profile",
+)
+@click.option(
+    "--no-restore",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Don't restore VM before making profile and don't destroy after, assume it's already running",
+)
+def make_profile(vm_id, no_restore):
+    install_info = InstallInfo.load(INSTALL_INFO_PATH)
+    network_conf = NetworkConfiguration.load(NETWORK_CONF_PATH)
+
+    vm = VirtualMachine(vm_id, install_info, network_conf)
+    if not no_restore:
+        vm.restore()
+    try:
+        vmi_info = create_vmi_info(vm, with_drakshell=False)
+        if vmi_info.inject_tid:
+            try:
+                drakshell = Drakshell(vm.vm_name)
+                drakshell.connect()
+                drakshell_info = drakshell.get_info()
+                assert (
+                    drakshell_info["pid"] == vmi_info.inject_pid
+                    or drakshell_info["tid"] == vmi_info.inject_tid
+                )
+            except Exception as e:
+                log.warning(
+                    "Drakshell is not running or has incorrect state. Removing inject_tid. "
+                    "Consider making a new vm0 snapshot using modify-vm0 utility.",
+                    exc_info=e,
+                )
+                vmi_info.inject_tid = None
+                VMI_INFO_PATH.write_text(vmi_info.to_json(indent=4))
+
+        create_vmi_json_profile(vm, vmi_info)
+    finally:
+        if not no_restore:
+            vm.destroy()
+    log.info("Profile successfully created")


### PR DESCRIPTION
Adds "make-profile" command that allows to refresh profile based on vm-1 state in case we need only small changes.

This is rarely used but useful command during debugging and development.