### PR TITLE
Fix: tcpdump on drakN bridge instead of vifX.0-emu interface

### DIFF
--- a/drakrun/drakrun/analyzer.py
+++ b/drakrun/drakrun/analyzer.py
@@ -153,7 +153,7 @@ def run_vm(vm: DrakvufVM, options: AnalysisOptions):
 def run_tcpdump(vm: DrakvufVM, options: AnalysisOptions):
     # todo: start_tcpdump_collector should accept pathlib.Path
     return graceful_exit(
-        start_tcpdump_collector(vm.vm.get_domid(), str(options.output_dir))
+        start_tcpdump_collector(f"drak{vm.vm_id}", str(options.output_dir))
     )
 
 

--- a/drakrun/drakrun/lib/networking.py
+++ b/drakrun/drakrun/lib/networking.py
@@ -124,13 +124,13 @@ def delete_iptables_chains() -> None:
         subprocess.run(f"iptables {rule}", shell=True)
 
 
-def start_tcpdump_collector(domid: int, outfile: str) -> subprocess.Popen:
+def start_tcpdump_collector(bridge_name: str, outfile: str) -> subprocess.Popen:
     try:
         subprocess.run("tcpdump --version", shell=True, check=True)
     except subprocess.CalledProcessError:
         raise RuntimeError("Failed to start tcpdump")
 
-    return subprocess.Popen(["tcpdump", "-i", f"vif{domid}.0-emu", "-w", outfile])
+    return subprocess.Popen(["tcpdump", "-i", bridge_name, "-w", outfile])
 
 
 def start_dnsmasq(dns_server: str, bridge_name: str, vm_ip: str, dnsmasq_pidfile: str):


### PR DESCRIPTION
Isolated from #1007.

On my testbed I don't have the Emulated interface because I use PV drivers for networking. We should not even bother about Xen virtual interfaces because we're already providing a bridge that is unique for each VM.
