### PR TITLE
Fix: sync Drakvuf initialization with drakshell execution

### DIFF
--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -21,7 +21,7 @@ from drakrun.lib.paths import (
 from .analysis_options import AnalysisOptions
 from .post_restore import get_post_restore_command
 from .postprocessing import postprocess_output_dir
-from .run_tools import run_drakvuf, run_tcpdump, run_vm
+from .run_tools import run_drakvuf, run_tcpdump, run_vm, wait_until_file_not_empty
 from .startup_command import get_startup_argv, get_target_filename_from_sample_path
 
 log = logging.getLogger(__name__)
@@ -190,6 +190,7 @@ def analyze_file(
             with run_tcpdump(network_info, tcpdump_file), run_drakvuf(
                 vm.vm_name, vmi_info, kernel_profile_path, drakmon_file, drakvuf_args
             ) as drakvuf:
+                wait_until_file_not_empty(drakmon_file, 15)
                 if options.start_command is not None:
                     log.info(f"Running command: {guest_path}.")
                     drakshell.run([guest_path], terminate_drakshell=True)

--- a/drakrun/analyzer/run_tools.py
+++ b/drakrun/analyzer/run_tools.py
@@ -1,6 +1,7 @@
 import contextlib
 import pathlib
 import subprocess
+import time
 from typing import List
 
 from drakrun.lib.config import NetworkConfigSection
@@ -70,3 +71,18 @@ def run_vm(
             yield vm
         finally:
             vm.destroy()
+
+
+def wait_until_file_not_empty(file_path: pathlib.Path, timeout: int):
+    start_time = time.time()
+    with file_path.open("rb") as f:
+        while True:
+            buf = f.read(1)
+            if buf:
+                return True
+            end_time = time.time()
+            if end_time - start_time > timeout:
+                raise RuntimeError(
+                    f"Reached timeout while waiting for output in {file_path.as_posix()}"
+                )
+            time.sleep(0.5)


### PR DESCRIPTION
Fixes #1042

Sample need to be started after Drakvuf monitoring is fully initialized. Right now I don't have better idea than checking if something was written to drakvuf.log

It will delay sample execution a bit, but Drakvuf should quickly emit enough data to flush the buffer and write something to output file.