### PR TITLE
Run sample using injector and evacuate drakshell on injection

### DIFF
--- a/drakrun/analyzer/run_tools.py
+++ b/drakrun/analyzer/run_tools.py
@@ -1,7 +1,7 @@
 import contextlib
 import pathlib
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from drakrun.lib.config import NetworkConfigSection
 from drakrun.lib.drakvuf_cmdline import get_base_drakvuf_cmdline
@@ -38,11 +38,13 @@ def run_drakvuf(
     kernel_profile_path: str,
     output_file: pathlib.Path,
     drakvuf_args: List[str],
+    exec_cmd: Optional[str] = None,
 ):
     drakvuf_cmdline = get_base_drakvuf_cmdline(
         vm_name,
         kernel_profile_path,
         vmi_info,
+        exec_cmd=exec_cmd,
         extra_args=drakvuf_args,
     )
 

--- a/drakrun/lib/drakvuf_cmdline.py
+++ b/drakrun/lib/drakvuf_cmdline.py
@@ -34,7 +34,7 @@ def get_base_drakvuf_cmdline(
                 "-e",
                 exec_cmd,
                 *(
-                    ["-I", str(vmi_info.inject_tid)]
+                    ["-I", str(vmi_info.inject_tid), "--exit-injection-thread"]
                     if vmi_info.inject_tid is not None
                     else []
                 ),

--- a/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/tools/drakshell/drakshell.c
@@ -735,7 +735,7 @@ static bool send_info(HANDLE hComm) {
     return true;
 }
 
-void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_loop(HANDLE hComm) {
+void __attribute__((noinline)) __attribute__((ms_abi)) drakshell_loop(HANDLE hComm) {
     while(true) {
         BYTE control = 0;
         if(!recv_control(hComm, &control)) {

--- a/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/tools/drakshell/drakshell.c
@@ -735,7 +735,7 @@ static bool send_info(HANDLE hComm) {
     return true;
 }
 
-void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_loop(HANDLE hComm) {
+void __attribute__((noinline)) drakshell_loop(HANDLE hComm) {
     while(true) {
         BYTE control = 0;
         if(!recv_control(hComm, &control)) {

--- a/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/tools/drakshell/drakshell.c
@@ -735,48 +735,7 @@ static bool send_info(HANDLE hComm) {
     return true;
 }
 
-void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
-    DCB dcb = { .DCBlength = sizeof(DCB) };
-
-    if(!load_winapi()) {
-        // Failed to load some WinAPI functions
-        return;
-    }
-
-    Sleep(500); // Some sleep to let injector finish his job
-
-    OutputDebugStringW(L"Hello from drakshell");
-
-    HANDLE hComm = CreateFileW(
-        L"\\\\.\\COM1",
-        GENERIC_READ | GENERIC_WRITE,
-        0,
-        NULL,
-        OPEN_EXISTING,
-        FILE_FLAG_OVERLAPPED,
-        NULL
-    );
-
-    if(hComm == INVALID_HANDLE_VALUE)
-    {
-        OutputDebugStringW(L"Failed to connect to COM1");
-        return;
-    }
-
-    if(!BuildCommDCB("baud=115200 parity=N data=8 stop=1", &dcb))
-    {
-        OutputDebugStringW(L"Failed to get DCB for COM1");
-        return;
-    }
-
-    if(!SetCommState(hComm, &dcb))
-    {
-        OutputDebugStringW(L"Failed to set mode of COM1");
-        return;
-    }
-
-    OutputDebugStringW(L"Connected to COM1");
-
+void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_loop(HANDLE hComm) {
     while(true) {
         BYTE control = 0;
         if(!recv_control(hComm, &control)) {
@@ -857,6 +816,63 @@ void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshel
             }
         }
     }
+}
+
+void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_main() {
+    DCB dcb = { .DCBlength = sizeof(DCB) };
+
+    if(!load_winapi()) {
+        // Failed to load some WinAPI functions
+        return;
+    }
+
+    Sleep(500); // Some sleep to let injector finish his job
+
+    OutputDebugStringW(L"Hello from drakshell");
+
+    HANDLE hComm = CreateFileW(
+        L"\\\\.\\COM1",
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+
+    if(hComm == INVALID_HANDLE_VALUE)
+    {
+        OutputDebugStringW(L"Failed to connect to COM1");
+        return;
+    }
+
+    if(!BuildCommDCB("baud=115200 parity=N data=8 stop=1", &dcb))
+    {
+        OutputDebugStringW(L"Failed to get DCB for COM1");
+        return;
+    }
+
+    if(!SetCommState(hComm, &dcb))
+    {
+        OutputDebugStringW(L"Failed to set mode of COM1");
+        return;
+    }
+
+    OutputDebugStringW(L"Connected to COM1");
+
+	// It's convenient to wrap the loop in separate thread.
+	// Drakvuf can signal end of injection by exiting it
+	// via --exit-injection-thread. This enables us to clean up
+	// the shellcode from the memory after the drakshell_loop is terminated
+	HANDLE hThread = CreateThread(
+        NULL, 0,
+        drakshell_loop,
+        (void*)hComm,
+        0, NULL
+    )
+    WaitForSingleObject(hThread, (DWORD)-1);
+	CloseHandle(hThread);
+
     OutputDebugStringW(L"Bye");
     CloseHandle(hComm);
 }

--- a/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/tools/drakshell/drakshell.c
@@ -735,7 +735,7 @@ static bool send_info(HANDLE hComm) {
     return true;
 }
 
-void __attribute__((noinline)) drakshell_loop(HANDLE hComm) {
+void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshell_loop(HANDLE hComm) {
     while(true) {
         BYTE control = 0;
         if(!recv_control(hComm, &control)) {

--- a/drakrun/tools/drakshell/drakshell.c
+++ b/drakrun/tools/drakshell/drakshell.c
@@ -869,7 +869,7 @@ void __attribute__((noinline)) __attribute__((force_align_arg_pointer)) drakshel
         drakshell_loop,
         (void*)hComm,
         0, NULL
-    )
+    );
     WaitForSingleObject(hThread, (DWORD)-1);
 	CloseHandle(hThread);
 

--- a/drakrun/tools/drakshell/include/nt_loader.h
+++ b/drakrun/tools/drakshell/include/nt_loader.h
@@ -135,7 +135,7 @@ typedef struct _OVERLAPPED {
 
 #define WINAPI __attribute__((ms_abi))
 
-typedef int (WINAPI* PCreateThread)(
+typedef HANDLE (WINAPI* PCreateThread)(
     LPVOID lpThreadAttributes,
     SIZE_T dwStackSize,
     LPVOID lpStartAddress,

--- a/drakrun/tools/drakshell/nt_loader.c
+++ b/drakrun/tools/drakshell/nt_loader.c
@@ -239,7 +239,7 @@ PBuildCommDCB pBuildCommDCB;
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
 
-	pCreateThread = get_func_from_peb(L"kernel32.dll", "CreateThread");
+    pCreateThread = get_func_from_peb(L"kernel32.dll", "CreateThread");
     pLoadLibraryW = get_func_from_peb(L"kernel32.dll", "LoadLibraryW");
     pGetProcAddress = get_func_from_peb(L"kernel32.dll", "GetProcAddress");
     if(!pLoadLibraryW || !pGetProcAddress) {

--- a/drakrun/tools/drakshell/nt_loader.c
+++ b/drakrun/tools/drakshell/nt_loader.c
@@ -204,6 +204,7 @@ void* get_func_from_peb(const wchar_t* libraryName, const char* procName)
     return NULL;
 }
 
+PCreateThread pCreateThread;
 PLoadLibraryW pLoadLibraryW;
 PGetProcAddress pGetProcAddress;
 PMessageBoxA pMessageBoxA;

--- a/drakrun/tools/drakshell/nt_loader.c
+++ b/drakrun/tools/drakshell/nt_loader.c
@@ -239,6 +239,7 @@ PBuildCommDCB pBuildCommDCB;
 bool load_winapi() {
     HANDLE hKernel32, hUser32;
 
+	pCreateThread = get_func_from_peb(L"kernel32.dll", "CreateThread");
     pLoadLibraryW = get_func_from_peb(L"kernel32.dll", "LoadLibraryW");
     pGetProcAddress = get_func_from_peb(L"kernel32.dll", "GetProcAddress");
     if(!pLoadLibraryW || !pGetProcAddress) {


### PR DESCRIPTION
When sample and Drakvuf are executed asynchronously, it may cause weird effects like https://github.com/CERT-Polska/drakvuf-sandbox/issues/1042. We're also limiting ourselves to execution via drakshell while drakshell should be an opt-out addition.

I this PR I included the following changes:
- wrapped drakshell main loop in extra thread (drakshell_loop) which is tracked by drakshell_main. If drakshell_loop exits by external or internal termination, drakshell_main does the necessary cleanup.
- sample is executed using injector with  "--exit-injection-thread" flag when `inject_tid` is set. This is meant to terminate drakshell_loop and evacuate the drakshell from the explorer.exe memory before the sample is fully loaded.
- bugfix: `options.start_command` is used as a command-line instead of `guest_path`