### PR TITLE
analyzer: Make automatic screenshots during analysis

### DIFF
--- a/drakrun/analyzer/analysis_options.py
+++ b/drakrun/analyzer/analysis_options.py
@@ -33,6 +33,8 @@ class AnalysisOptions(BaseModel):
     no_vm_restore: Optional[bool] = None
     # Don't run a post-restore script
     no_post_restore: Optional[bool] = None
+    # Don't make screenshots during analysis
+    no_screenshotter: Optional[bool] = None
 
     def __init__(self, config: DrakrunConfig, **kwargs):
         net_enable = kwargs.get("net_enable")

--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -23,7 +23,7 @@ from drakrun.lib.paths import (
 from .analysis_options import AnalysisOptions
 from .post_restore import get_post_restore_command
 from .postprocessing import postprocess_output_dir
-from .run_tools import run_drakvuf, run_tcpdump, run_vm
+from .run_tools import run_drakvuf, run_screenshotter, run_tcpdump, run_vm
 from .startup_command import get_startup_argv, get_target_filename_from_sample_path
 
 log = logging.getLogger(__name__)
@@ -196,7 +196,9 @@ def analyze_file(
                 drakshell.finish()
                 exec_cmd = None
 
-            with run_tcpdump(network_info, tcpdump_file), run_drakvuf(
+            with run_tcpdump(network_info, tcpdump_file), run_screenshotter(
+                vm_id, install_info, output_dir
+            ), run_drakvuf(
                 vm.vm_name,
                 vmi_info,
                 kernel_profile_path,

--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -197,7 +197,7 @@ def analyze_file(
                 exec_cmd = None
 
             with run_tcpdump(network_info, tcpdump_file), run_screenshotter(
-                vm_id, install_info, output_dir
+                vm_id, install_info, output_dir, enabled=(not options.no_screenshotter)
             ), run_drakvuf(
                 vm.vm_name,
                 vmi_info,

--- a/drakrun/analyzer/postprocessing/plugins/__init__.py
+++ b/drakrun/analyzer/postprocessing/plugins/__init__.py
@@ -7,6 +7,7 @@ from .generate_report import build_report
 from .generate_wireshark_key_file import generate_wireshark_key_file
 from .index_logs import index_logs
 from .plugin_base import PostprocessPlugin
+from .screenshot_metadata import screenshot_metadata
 from .split_drakmon_log import split_drakmon_log
 
 POSTPROCESS_PLUGINS = [
@@ -38,6 +39,11 @@ POSTPROCESS_PLUGINS = [
         function=build_report,
         requires=[],
         generates=["report.json"],
+    ),
+    PostprocessPlugin(
+        function=screenshot_metadata,
+        requires=["screenshots.json"],
+        generates=[],
     ),
     PostprocessPlugin(function=crop_dumps, requires=["dumps"], generates=["dumps.zip"]),
     PostprocessPlugin(function=compress_ipt, requires=["ipt"], generates=["ipt.zip"]),

--- a/drakrun/analyzer/postprocessing/plugins/screenshot_metadata.py
+++ b/drakrun/analyzer/postprocessing/plugins/screenshot_metadata.py
@@ -1,0 +1,17 @@
+import json
+import pathlib
+from typing import Any, Dict
+
+
+def screenshot_metadata(analysis_dir: pathlib.Path) -> Dict[str, Any]:
+    """
+    Checks if every line is parseable and exposes screenshot amount in metadata object.
+    We can perform some postprocessing here if needed in the future.
+    """
+    screenshots_data = (analysis_dir / "screenshots.json").read_text().splitlines()
+    last_index = 0
+    for dataline in screenshots_data:
+        if dataline:
+            screenshot_data = json.loads(dataline)
+            last_index = screenshot_data["index"]
+    return {"screenshots": last_index}

--- a/drakrun/analyzer/run_tools.py
+++ b/drakrun/analyzer/run_tools.py
@@ -3,6 +3,7 @@ import pathlib
 import subprocess
 from typing import List, Optional
 
+from drakrun.analyzer.screenshotter import Screenshotter
 from drakrun.lib.config import NetworkConfigSection
 from drakrun.lib.drakvuf_cmdline import get_base_drakvuf_cmdline
 from drakrun.lib.install_info import InstallInfo
@@ -72,3 +73,22 @@ def run_vm(
             yield vm
         finally:
             vm.destroy()
+
+
+@contextlib.contextmanager
+def run_screenshotter(
+    vm_id: int,
+    install_info: InstallInfo,
+    output_dir: pathlib.Path,
+):
+    screenshotter = Screenshotter(
+        output_dir=output_dir,
+        vnc_host="localhost",
+        vnc_port=5900 + vm_id,
+        vnc_password=install_info.vnc_passwd,
+    )
+    try:
+        screenshotter.start()
+        yield
+    finally:
+        screenshotter.stop()

--- a/drakrun/analyzer/run_tools.py
+++ b/drakrun/analyzer/run_tools.py
@@ -80,7 +80,10 @@ def run_screenshotter(
     vm_id: int,
     install_info: InstallInfo,
     output_dir: pathlib.Path,
+    enabled: bool = True,
 ):
+    if not enabled:
+        return
     screenshotter = Screenshotter(
         output_dir=output_dir,
         vnc_host="localhost",

--- a/drakrun/analyzer/screenshotter.py
+++ b/drakrun/analyzer/screenshotter.py
@@ -1,0 +1,82 @@
+import asyncio
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+
+import asyncvnc
+from perception import hashers
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+class Screenshotter:
+    def __init__(
+        self,
+        output_dir: Path,
+        vnc_host: str,
+        vnc_port: int,
+        vnc_password: str,
+        loop_interval=5,
+        max_screenshots=30,
+    ):
+        self._aioloop = None
+        self._thread = None
+
+        self.output_dir = output_dir
+        self.vnc_host = vnc_host
+        self.vnc_port = vnc_port
+        self.vnc_password = vnc_password
+        self.loop_interval = loop_interval
+        self.max_screenshots = max_screenshots
+
+    async def perform(self):
+        hasher = hashers.PHash()
+        prev_image_hash = None
+        screenshot_no = 0
+        screenshot_log_path = self.output_dir / "screenshots.json"
+        screenshot_dir = self.output_dir / "screenshots"
+        screenshot_dir.mkdir()
+        with screenshot_log_path.open("w") as screenshot_log:
+            async with asyncvnc.connect(
+                host=self.vnc_host, port=self.vnc_port, password=self.vnc_password
+            ) as client:
+                while screenshot_no < self.max_screenshots:
+                    pixels = await client.screenshot()
+                    timestamp = time.time()
+                    image = Image.fromarray(pixels)
+                    image_hash = hasher.compute(image)
+                    if prev_image_hash != image_hash:
+                        screenshot_no += 1
+                        screenshot_name = (
+                            screenshot_dir / f"screenshot_{screenshot_no}.png"
+                        )
+                        image.save(screenshot_name)
+                        screenshot_log.write(
+                            json.dumps(
+                                {
+                                    "timestamp": timestamp,
+                                    "image_hash": image_hash,
+                                    "index": screenshot_no,
+                                }
+                            )
+                            + "\n"
+                        )
+                    await asyncio.sleep(self.loop_interval)
+
+    def perform_loop(self):
+        try:
+            self._aioloop.run_until_complete(self.perform())
+        finally:
+            self._aioloop.close()
+
+    def start(self):
+        self._aioloop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self.perform_loop)
+        self._thread.start()
+
+    def stop(self):
+        self._aioloop.stop()
+        self._thread.join()

--- a/drakrun/analyzer/screenshotter.py
+++ b/drakrun/analyzer/screenshotter.py
@@ -43,6 +43,7 @@ class Screenshotter:
             async with asyncvnc.connect(
                 host=self.vnc_host, port=self.vnc_port, password=self.vnc_password
             ) as client:
+                logger.info(f"Connected to VNC {self.vnc_host}:{self.vnc_port}")
                 while screenshot_no < self.max_screenshots:
                     pixels = await client.screenshot()
                     timestamp = time.time()
@@ -64,6 +65,7 @@ class Screenshotter:
                             )
                             + "\n"
                         )
+                        logger.info(f"Got screenshot {screenshot_no}: {image_hash}")
                     await asyncio.sleep(self.loop_interval)
 
     def perform_loop(self):

--- a/drakrun/cli/analyze.py
+++ b/drakrun/cli/analyze.py
@@ -80,6 +80,12 @@ from drakrun.lib.config import load_config
     is_flag=True,
     help="Don't run a post-restore script",
 )
+@click.option(
+    "--no-screenshotter",
+    "no_screenshotter",
+    is_flag=True,
+    help="Don't make screenshots during analysis",
+)
 def analyze(
     vm_id,
     output_dir,
@@ -91,6 +97,7 @@ def analyze(
     net_enable,
     no_restore,
     no_post_restore,
+    no_screenshotter,
 ):
     """
     Run a CLI analysis using Drakvuf
@@ -120,6 +127,7 @@ def analyze(
         plugins=plugins,
         no_vm_restore=no_restore,
         no_post_restore=no_post_restore,
+        no_screenshotter=no_screenshotter,
     )
 
     extra_metadata = analyze_file(vm_id=vm_id, output_dir=output_dir, options=options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python-magic==0.4.27
 rq-dashboard==0.8.2.2
 # Screenshotter dependencies
 asyncvnc==1.3.0
-Pillow==11.2.1
+Pillow==10.4.0
 Perception==0.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ rq-dashboard==0.8.2.2
 # Screenshotter dependencies
 asyncvnc==1.3.0
 Pillow==10.4.0
-Perception==0.7.7
+Perception==0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ rq==2.3.1
 Flask==3.0.3
 python-magic==0.4.27
 rq-dashboard==0.8.2.2
+# Screenshotter dependencies
+asyncvnc==1.3.0
+Pillow==11.2.1
+Perception==0.7.7


### PR DESCRIPTION
- Analyzer connects to VNC and makes periodic screenshots. If screenshot perceptual hash significantly differs, screenshot is stored in `screenshots` subdir of analysis directory
- `screenshots.json` aggregates information about timestamp, hashes and screenshot index

closes https://github.com/CERT-Polska/drakvuf-sandbox/issues/608