### PR TITLE
Bump minimal Python version to 3.9, fix linter configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 extend-ignore=E501,E203
 max-line-length=88
-exclude=drakrun/data,drakrun/tools
+exclude=drakrun/data,drakrun/tools,drakrun/web/frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         working-directory: docs
         run: pip install -r requirements.txt
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: CERT-Polska/lint-python-action@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
   build_drakrun_tools:
     runs-on: ubuntu-latest
     container: "debian:bookworm"
@@ -77,7 +77,7 @@ jobs:
   build_drakrun:
     needs: [ build_drakrun_tools, build_drakrun_web ]
     runs-on: ubuntu-latest
-    container: "python:3.8"
+    container: "python:3.9"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -42,8 +42,7 @@ class AnalysisSubstatusCallback(Protocol):
         self,
         substatus: AnalysisSubstatus,
         updated_options: Optional[AnalysisOptions] = None,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 def prepare_output_dir(output_dir: pathlib.Path, options: AnalysisOptions) -> None:

--- a/drakrun/analyzer/postprocessing/plugins/plugin_base.py
+++ b/drakrun/analyzer/postprocessing/plugins/plugin_base.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Protocol
 
 
 class PostprocessFunction(Protocol):
-    def __call__(self, analysis_dir: pathlib.Path) -> Optional[Dict[str, Any]]:
-        ...
+    def __call__(self, analysis_dir: pathlib.Path) -> Optional[Dict[str, Any]]: ...
 
 
 class PostprocessPlugin(NamedTuple):

--- a/drakrun/analyzer/worker.py
+++ b/drakrun/analyzer/worker.py
@@ -31,7 +31,6 @@ def get_redis_connection(config: RedisConfigSection):
 
 
 def worker_analyze(options: AnalysisOptions):
-    global _WORKER_VM_ID
     if _WORKER_VM_ID is None:
         raise RuntimeError("Fatal error: no vm_id assigned in worker")
 

--- a/drakrun/web/app.py
+++ b/drakrun/web/app.py
@@ -117,9 +117,9 @@ def analysis_job_to_dict(job: Job):
         "file": job_meta.get("file"),
         "options": job_meta.get("options"),
         "vm_id": job_meta.get("vm_id"),
-        "time_started": job.started_at.isoformat()
-        if job.started_at is not None
-        else None,
+        "time_started": (
+            job.started_at.isoformat() if job.started_at is not None else None
+        ),
         "time_finished": job.ended_at.isoformat() if job.ended_at is not None else None,
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.isort]
 profile = "black"
-skip_glob = ["drakrun/data/**/*", "drakrun/tools/**/*"]
+skip_glob = ["drakrun/data/**/*", "drakrun/tools/**/*", "drakrun/web/frontend/**/*"]
 
 [tool.black]
-exclude = "drakrun/(data|tools)"
+exclude = "drakrun/(data|tools|web/frontend)"
 
 [tool.lint-python]
 lint-version = "2"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_dir={"drakrun": "drakrun"},
     packages=find_packages(),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
3.8 is EOL and it's difficult to bump dependencies. Recommended Debian 12 comes with Python 3.11.