### PR TITLE
Fix: missing Perception peer dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ rq-dashboard==0.8.2.2
 asyncvnc==1.3.0
 Pillow==10.4.0
 Perception==0.6.8
+# Perception missing peer dependency
+opencv-contrib-python-headless==4.11.0.86


### PR DESCRIPTION
Fix for `ModuleNotFoundError: No module named 'cv2'` message after fresh installation