### PR TITLE
Fix: don't parse plugins explicitly in upload endpoint

### DIFF
--- a/drakrun/web/api.py
+++ b/drakrun/web/api.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import logging
 import shutil
 import uuid
@@ -71,9 +70,6 @@ def upload_sample(form: UploadFileForm):
             filename = request_file.filename
         start_command = form.start_command
         plugins = form.plugins
-        if plugins:
-            plugins = json.loads(plugins)
-
         file_metadata = FileMetadata(
             name=filename,
             type=sample_magic,

--- a/drakrun/web/schema.py
+++ b/drakrun/web/schema.py
@@ -14,7 +14,7 @@ class UploadFileForm(BaseModel):
     timeout: Optional[int] = Field(default=None, description="Analysis timeout")
     file_name: Optional[str] = Field(default=None, description="Target file name")
     start_command: Optional[str] = Field(default=None, description="Start command")
-    plugins: Optional[str] = Field(
+    plugins: Optional[List[str]] = Field(
         default=None, description="Plugins to use (in JSON array string)"
     )
 


### PR DESCRIPTION
flask-openapi3 tries to parse JSONs from form fields automatically, so we should just expect a list of plugins in the scheme