### PR TITLE
Bump version: v0.19.0-alpha3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = '2025, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.19.0-alpha2'
+release = 'v0.19.0-alpha3'
 
 latex_engine = 'xelatex'
 

--- a/drakrun/version.py
+++ b/drakrun/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.19.0-alpha2"
+__version__ = "0.19.0-alpha3"

--- a/drakrun/web/frontend/package-lock.json
+++ b/drakrun/web/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@drakvuf-sandbox/web",
-  "version": "0.19.0-alpha2",
+  "version": "0.19.0-alpha3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@drakvuf-sandbox/web",
-      "version": "0.19.0-alpha2",
+      "version": "0.19.0-alpha3",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-regular-svg-icons": "^6.7.2",

--- a/drakrun/web/frontend/package.json
+++ b/drakrun/web/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@drakvuf-sandbox/web",
   "private": true,
-  "version": "0.19.0-alpha2",
+  "version": "0.19.0-alpha3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/drakrun/web/frontend/src/App.jsx
+++ b/drakrun/web/frontend/src/App.jsx
@@ -58,7 +58,7 @@ function AppSidenav() {
                     </div>
                 </div>
                 <div className="sb-sidenav-footer">
-                    <div className="small">v0.19.0-alpha2</div>
+                    <div className="small">v0.19.0-alpha3</div>
                 </div>
             </nav>
         </div>


### PR DESCRIPTION
New changes:

* Automatic screenshots during analysis process (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1052, https://github.com/CERT-Polska/drakvuf-sandbox/pull/1063)
* drakweb: Moved API endpoints under /api prefix. API is now documented and using flask-openapi3 for generating OpenAPI specification and validation (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1068)
* drakweb: Filtered process logs viewer (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1064)
* Sample is run using injector and drakshell is evacuated on injection. It's recommended to run this version with latest DRAKVUF to include [this patch](https://github.com/tklengyel/drakvuf/commit/9833fa5ffd821b11aa78ef8a7a455da623580b55) (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1047)
* Minimal Python version is now 3.9 (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1055)
* DRAKVUF analysis report generation  -`report.json` (by @yelhamer in https://github.com/CERT-Polska/drakvuf-sandbox/pull/940)
* Unified status and metadata.json - use `/api/status` endpoint instead of `/metadata` to get the basic information about analysis task (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1061)

Bugfixes:

* Fix: missing mkdirs VMI_PROFILES_DIR/PDB_CACHE_DIR (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1045)
* Fix: resolve ISO path, VM-0 won't reboot with relative one (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1044)
* Fix: capa-rules submodule reference (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1057). Pinned capa-rules and capa to 7.4.0 (https://github.com/CERT-Polska/drakvuf-sandbox/pull/1059)
* Fix memdump directory mismatch (by @grzetzp in https://github.com/CERT-Polska/drakvuf-sandbox/pull/1071)

Known issues:

* `drakrun mount` doesn't work (https://github.com/CERT-Polska/drakvuf-sandbox/issues/1070)