### PR TITLE
Compact log index

### DIFF
--- a/drakrun/analyzer/postprocessing/indexer.py
+++ b/drakrun/analyzer/postprocessing/indexer.py
@@ -1,9 +1,9 @@
 import logging
-import msgpack
 import pathlib
 from collections import defaultdict
 from typing import List, Optional
 
+import msgpack
 import orjson
 
 from .process_tree import ProcessTree
@@ -72,10 +72,8 @@ def index_log_file(
                 logger.exception("Failed to process entry")
     return dict(index)
 
-def build_log_index(
-    analysis_dir: pathlib.Path,
-    process_tree: ProcessTree
-) -> bytes:
+
+def build_log_index(analysis_dir: pathlib.Path, process_tree: ProcessTree) -> bytes:
     log_index = [dict() for _ in range(len(process_tree.processes))]
     for log_file_path in analysis_dir.glob("*.log"):
         plugin_name = log_file_path.stem
@@ -99,12 +97,10 @@ def build_log_index(
             serialized_indexes.append(serialized_index)
             serialized_indexes_current += len(serialized_index)
     serialized_index_toc = msgpack.packb(index_toc)
-    return serialized_index_toc + b''.join(serialized_indexes)
+    return serialized_index_toc + b"".join(serialized_indexes)
 
-def get_plugin_names_for_process(
-    index_file: pathlib.Path,
-    seqid: int
-):
+
+def get_plugin_names_for_process(index_file: pathlib.Path, seqid: int):
     with index_file.open("rb") as f:
         unpacker = msgpack.Unpacker(f)
         index_toc = unpacker.unpack()
@@ -113,11 +109,7 @@ def get_plugin_names_for_process(
         return list(index_toc[seqid].keys())
 
 
-def get_log_index_for_process(
-    index_file: pathlib.Path,
-    seqid: int,
-    plugin_name: str
-):
+def get_log_index_for_process(index_file: pathlib.Path, seqid: int, plugin_name: str):
     with index_file.open("rb") as f:
         unpacker = msgpack.Unpacker(f)
         index_toc = unpacker.unpack()

--- a/drakrun/analyzer/postprocessing/indexer.py
+++ b/drakrun/analyzer/postprocessing/indexer.py
@@ -95,11 +95,43 @@ def build_log_index(
     for proc_seqid, proc_log_index in enumerate(log_index):
         for plugin_name, plugin_index in proc_log_index.items():
             serialized_index = msgpack.packb(plugin_index)
-            index_toc[proc_seqid][plugin_name] = [serialized_indexes_current, serialized_indexes_current + len(serialized_index)]
+            index_toc[proc_seqid][plugin_name] = serialized_indexes_current
             serialized_indexes.append(serialized_index)
             serialized_indexes_current += len(serialized_index)
     serialized_index_toc = msgpack.packb(index_toc)
     return serialized_index_toc + b''.join(serialized_indexes)
+
+def get_plugin_names_for_process(
+    index_file: pathlib.Path,
+    seqid: int
+):
+    with index_file.open("rb") as f:
+        unpacker = msgpack.Unpacker(f)
+        index_toc = unpacker.unpack()
+        if seqid >= len(index_toc):
+            return []
+        return list(index_toc[seqid].keys())
+
+
+def get_log_index_for_process(
+    index_file: pathlib.Path,
+    seqid: int,
+    plugin_name: str
+):
+    with index_file.open("rb") as f:
+        unpacker = msgpack.Unpacker(f)
+        index_toc = unpacker.unpack()
+        log_pos = unpacker.tell()
+        if seqid >= len(index_toc):
+            return None
+        if plugin_name not in index_toc[seqid]:
+            return None
+        start = index_toc[seqid][plugin_name]
+        # Seek to the specific point of file
+        f.seek(log_pos + start)
+        unpacker = msgpack.Unpacker(f)
+        return unpacker.unpack()
+
 
 def scattered_read_file(
     log_file: pathlib.Path,

--- a/drakrun/analyzer/postprocessing/plugins/__init__.py
+++ b/drakrun/analyzer/postprocessing/plugins/__init__.py
@@ -50,6 +50,6 @@ POSTPROCESS_PLUGINS = [
     PostprocessPlugin(function=crop_dumps, requires=[DUMPS_DIR], generates=[DUMPS_ZIP]),
     PostprocessPlugin(function=compress_ipt, requires=[IPT_DIR], generates=[IPT_ZIP]),
     PostprocessPlugin(
-        function=index_logs, requires=["procmon.log"], generates=["index"]
+        function=index_logs, requires=["process_tree.json"], generates=["log_index"]
     ),
 ]

--- a/drakrun/analyzer/postprocessing/plugins/index_logs.py
+++ b/drakrun/analyzer/postprocessing/plugins/index_logs.py
@@ -1,31 +1,13 @@
 import json
 import pathlib
 
-from ..indexer import index_log_file
-from ..process_tree import tree_from_log
+from ..indexer import build_log_index
+from ..process_tree import tree_from_dict
 
 
 def index_logs(analysis_dir: pathlib.Path) -> None:
-    index_dir = analysis_dir / "index"
-    index_dir.mkdir(exist_ok=True)
-
-    # TODO: I need ProcessTree object but right now
-    #       I can't easily load it from process_tree.json
-
-    procmon_log_path = analysis_dir / "procmon.log"
-    with procmon_log_path.open("r") as procmon_log:
-        process_tree = tree_from_log(procmon_log)
-
-    for log_file_path in analysis_dir.glob("*.log"):
-        plugin_name = log_file_path.stem
-        if plugin_name == "drakrun":
-            continue
-        index = index_log_file(
-            log_file_path,
-            process_tree,
-            key="Method",
-        )
-
-        for seqid in index.keys():
-            index_path = index_dir / f"{plugin_name}.{seqid}.json"
-            index_path.write_text(json.dumps(index[seqid]))
+    process_tree_dict = json.loads((analysis_dir / "process_tree.json").read_text())
+    process_tree = tree_from_dict(process_tree_dict)
+    index = build_log_index(analysis_dir, process_tree)
+    index_path = analysis_dir / "log_index"
+    index_path.write_bytes(index)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ Pillow==10.4.0
 Perception==0.6.8
 # Perception missing peer dependency
 opencv-contrib-python-headless==4.11.0.86
+# Also peer vivisect dependency, but we use it directly
+msgpack==1.0.8


### PR DESCRIPTION
- Make a single `log_index` file for logs instead of hundreds of `index/{name}.{seqid}.json` files
- Use msgpack to make it more compact