### PR TITLE
Fix: change Drakvuf working dir to analysis output dir

### DIFF
--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -206,6 +206,7 @@ def analyze_file(
                 drakmon_file,
                 drakvuf_args,
                 exec_cmd=exec_cmd,
+                cwd=output_dir,
             ) as drakvuf:
                 log.info("Analysis started...")
                 try:

--- a/drakrun/analyzer/run_tools.py
+++ b/drakrun/analyzer/run_tools.py
@@ -40,6 +40,7 @@ def run_drakvuf(
     output_file: pathlib.Path,
     drakvuf_args: List[str],
     exec_cmd: Optional[str] = None,
+    cwd: Optional[pathlib.Path] = None,
 ):
     drakvuf_cmdline = get_base_drakvuf_cmdline(
         vm_name,
@@ -50,7 +51,7 @@ def run_drakvuf(
     )
 
     with output_file.open("wb") as output:
-        drakvuf = subprocess.Popen(drakvuf_cmdline, stdout=output)
+        drakvuf = subprocess.Popen(drakvuf_cmdline, stdout=output, cwd=cwd)
         with process_graceful_exit(drakvuf):
             yield drakvuf
 


### PR DESCRIPTION
This change should allow to use relative paths in AnalysisOptions.extra_drakvuf_args.