### PR TITLE
Update nt_loader.c: fix PEB_LDR_DATA

### DIFF
--- a/drakrun/tools/drakshell/nt_loader.c
+++ b/drakrun/tools/drakshell/nt_loader.c
@@ -7,7 +7,7 @@ typedef struct _LIST_ENTRY {
 
 typedef struct _PEB_LDR_DATA {
     uint8_t Reserved1[8];
-    void* Reserved2[2];
+    void* Reserved2;
     LIST_ENTRY InLoadOrderModuleList;
     LIST_ENTRY InMemoryOrderModuleList;
     LIST_ENTRY InInitOrderModuleList;


### PR DESCRIPTION
PEB_LDR_DATA definition is wrong. I don't know why it was working...