### PR TITLE
Fix: issues when start_command is provided as str instead of list

### DIFF
--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -186,12 +186,17 @@ def analyze_file(
         drakvuf_args = prepare_drakvuf_args(output_dir, options)
 
         try:
+            if (
+                options.start_command is not None
+                and type(options.start_command) is list
+            ):
+                exec_cmd = mslex.join(options.start_command, for_cmd=False)
+                options.start_command = exec_cmd
+
             if substatus_callback is not None:
                 substatus_callback(AnalysisSubstatus.analyzing, updated_options=options)
 
-            if options.start_command is not None:
-                exec_cmd = mslex.join(options.start_command, for_cmd=False)
-            else:
+            if options.start_command is None:
                 # If we don't inject the command to run:
                 # evacuate the drakshell before running anything
                 drakshell.finish()

--- a/drakrun/web/frontend/src/AnalysisMetadataTable.jsx
+++ b/drakrun/web/frontend/src/AnalysisMetadataTable.jsx
@@ -1,7 +1,7 @@
 import { PluginList } from "./PluginPicker.jsx";
 
 export function AnalysisMetadataTable({ analysis }) {
-    const startCommand = (analysis.options["start_command"] || "-")
+    const startCommand = analysis.options["start_command"] || "-";
     return (
         <table className="datatable-table">
             <tbody>
@@ -20,7 +20,9 @@ export function AnalysisMetadataTable({ analysis }) {
                 <tr>
                     <th>Start command</th>
                     <td>
-                        {Array.isArray(startCommand) ? startCommand.join(" ") : startCommand}
+                        {Array.isArray(startCommand)
+                            ? startCommand.join(" ")
+                            : startCommand}
                     </td>
                 </tr>
                 <tr>

--- a/drakrun/web/frontend/src/AnalysisMetadataTable.jsx
+++ b/drakrun/web/frontend/src/AnalysisMetadataTable.jsx
@@ -1,6 +1,7 @@
 import { PluginList } from "./PluginPicker.jsx";
 
 export function AnalysisMetadataTable({ analysis }) {
+    const startCommand = (analysis.options["start_command"] || "-")
     return (
         <table className="datatable-table">
             <tbody>
@@ -19,7 +20,7 @@ export function AnalysisMetadataTable({ analysis }) {
                 <tr>
                     <th>Start command</th>
                     <td>
-                        {(analysis.options["start_command"] || ["-"]).join(" ")}
+                        {Array.isArray(startCommand) ? startCommand.join(" ") : startCommand}
                     </td>
                 </tr>
                 <tr>

--- a/drakrun/web/frontend/src/ProcessInfoTable.jsx
+++ b/drakrun/web/frontend/src/ProcessInfoTable.jsx
@@ -20,7 +20,7 @@ export function ProcessInfoTable({ processInfo }) {
                 </tr>
                 <tr>
                     <th>Arguments</th>
-                    <td>{processInfo.args.join(" ")}</td>
+                    <td>{Array.isArray(processInfo.args) ? processInfo.args.join(" ") : processInfo.args}</td>
                 </tr>
                 <tr>
                     <th>Started at</th>

--- a/drakrun/web/frontend/src/ProcessInfoTable.jsx
+++ b/drakrun/web/frontend/src/ProcessInfoTable.jsx
@@ -20,7 +20,11 @@ export function ProcessInfoTable({ processInfo }) {
                 </tr>
                 <tr>
                     <th>Arguments</th>
-                    <td>{Array.isArray(processInfo.args) ? processInfo.args.join(" ") : processInfo.args}</td>
+                    <td>
+                        {Array.isArray(processInfo.args)
+                            ? processInfo.args.join(" ")
+                            : processInfo.args}
+                    </td>
                 </tr>
                 <tr>
                     <th>Started at</th>


### PR DESCRIPTION
User can actually provide command line using both types. The list is then stringified using mslex, but originally appears in metadata just like provided by user.