### PR TITLE
Fix: set generated password length to 8 (this is the maximum length for VNC)

### DIFF
--- a/drakrun/cli/install.py
+++ b/drakrun/cli/install.py
@@ -81,7 +81,7 @@ def install(
 
     log.info("Performing installation...")
     passwd_characters = string.ascii_letters + string.digits
-    vnc_passwd = "".join(secrets.choice(passwd_characters) for _ in range(20))
+    vnc_passwd = "".join(secrets.choice(passwd_characters) for _ in range(8))
     install_info = InstallInfo(
         vcpus=vcpus,
         memory=memory,


### PR DESCRIPTION
Generating longer passwords gives false sense of security. VNC protocol doesn't accept more characters so password will be truncated to 8 chars anyway.

See also: closes #1040
