### PR TITLE
Various QoL changes: don't require root for all CLI commands, import analyzer lazily etc

### DIFF
--- a/drakrun/cli/analyze.py
+++ b/drakrun/cli/analyze.py
@@ -3,10 +3,7 @@ from datetime import datetime
 
 import click
 
-from drakrun.analyzer.analysis_options import AnalysisOptions
-from drakrun.analyzer.analyzer import analyze_file
-from drakrun.analyzer.postprocessing import append_metadata_to_analysis
-from drakrun.lib.config import load_config
+from .check_root import check_root
 
 
 @click.command("analyze")
@@ -93,6 +90,7 @@ from drakrun.lib.config import load_config
     is_flag=True,
     help="Don't make screenshots during analysis",
 )
+@check_root
 def analyze(
     vm_id,
     output_dir,
@@ -110,6 +108,11 @@ def analyze(
     """
     Run a CLI analysis using Drakvuf
     """
+    from drakrun.analyzer.analysis_options import AnalysisOptions
+    from drakrun.analyzer.analyzer import analyze_file
+    from drakrun.analyzer.postprocessing import append_metadata_to_analysis
+    from drakrun.lib.config import load_config
+
     config = load_config()
     if output_dir is None:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")

--- a/drakrun/cli/check_root.py
+++ b/drakrun/cli/check_root.py
@@ -1,0 +1,16 @@
+import functools
+import logging
+import os
+
+import click
+
+
+def check_root(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if os.geteuid() != 0:
+            logging.error("You need to have root privileges to run this command.")
+            raise click.Abort()
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/drakrun/cli/drakshell.py
+++ b/drakrun/cli/drakshell.py
@@ -17,6 +17,8 @@ from drakrun.lib.paths import (
 )
 from drakrun.lib.vm import VirtualMachine
 
+from .check_root import check_root
+
 log = logging.getLogger(__name__)
 
 
@@ -30,6 +32,7 @@ log = logging.getLogger(__name__)
     help="VM id to use for generating profile",
 )
 @click.argument("cmd", nargs=-1, type=str)
+@check_root
 def drakshell(vm_id, cmd):
     """
     Run drakshell session

--- a/drakrun/cli/drakvuf_cmdline.py
+++ b/drakrun/cli/drakvuf_cmdline.py
@@ -32,9 +32,6 @@ def drakvuf_cmdline(vm_id, cmd):
     install_info = InstallInfo.load(INSTALL_INFO_PATH)
 
     vm = VirtualMachine(vm_id, install_info, config.network)
-    if not vm.is_running:
-        raise RuntimeError("VM is not running")
-
     vmi_info = VmiInfo.load(VMI_INFO_PATH)
     print(
         shlex.join(

--- a/drakrun/cli/injector.py
+++ b/drakrun/cli/injector.py
@@ -13,12 +13,15 @@ from drakrun.lib.libvmi import VmiInfo
 from drakrun.lib.paths import INSTALL_INFO_PATH, VMI_INFO_PATH, VMI_KERNEL_PROFILE_PATH
 from drakrun.lib.vm import VirtualMachine
 
+from .check_root import check_root
+
 log = logging.getLogger(__name__)
 
 
 @click.group(
     name="injector", help="Copy files and execute commands on VM using injector"
 )
+@check_root
 def injector():
     pass
 

--- a/drakrun/cli/install.py
+++ b/drakrun/cli/install.py
@@ -12,6 +12,7 @@ from drakrun.lib.storage import REGISTERED_BACKEND_NAMES, get_storage_backend
 from drakrun.lib.vm import VirtualMachine
 
 from .banner import banner
+from .check_root import check_root
 from .sanity_check import sanity_check
 
 log = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ log = logging.getLogger(__name__)
     "lvm_volume_group",
     help="Volume group (only for lvm storage backend)",
 )
+@check_root
 def install(
     vcpus,
     memory,

--- a/drakrun/cli/main.py
+++ b/drakrun/cli/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import click
 
@@ -28,9 +27,6 @@ def main():
         handlers=[logging.StreamHandler()],
     )
     logging.getLogger("drakrun").setLevel(logging.DEBUG)
-    if os.geteuid() != 0:
-        logging.error("You need to have root privileges to run this command.")
-        raise click.Abort()
 
 
 main.add_command(analyze)

--- a/drakrun/cli/make_profile.py
+++ b/drakrun/cli/make_profile.py
@@ -9,6 +9,8 @@ from drakrun.lib.paths import INSTALL_INFO_PATH, VMI_INFO_PATH
 from drakrun.lib.vm import VirtualMachine
 from drakrun.lib.vmi_profile import create_vmi_info, create_vmi_json_profile
 
+from .check_root import check_root
+
 log = logging.getLogger(__name__)
 
 
@@ -28,6 +30,7 @@ log = logging.getLogger(__name__)
     default=False,
     help="Don't restore VM before making profile and don't destroy after, assume it's already running",
 )
+@check_root
 def make_profile(vm_id, no_restore):
     config = load_config()
     install_info = InstallInfo.load(INSTALL_INFO_PATH)

--- a/drakrun/cli/modify_vm0.py
+++ b/drakrun/cli/modify_vm0.py
@@ -12,11 +12,13 @@ from drakrun.lib.vm import VirtualMachine
 from drakrun.lib.vmi_profile import create_vmi_info, create_vmi_json_profile
 
 from .banner import banner
+from .check_root import check_root
 
 log = logging.getLogger(__name__)
 
 
 @click.group(name="modify-vm0", help="Modify base VM snapshot (vm-0)")
+@check_root
 def modify_vm0():
     pass
 

--- a/drakrun/cli/mount.py
+++ b/drakrun/cli/mount.py
@@ -5,6 +5,8 @@ import click
 from drakrun.lib.vm import FIRST_CDROM_DRIVE
 from drakrun.lib.xen import xen_insert_cd
 
+from .check_root import check_root
+
 
 @click.command(help="Mount ISO into guest", no_args_is_help=True)
 @click.argument("iso_path", type=click.Path(exists=True))
@@ -16,6 +18,7 @@ from drakrun.lib.xen import xen_insert_cd
     show_default=True,
     help="Domain name (i.e. Virtual Machine name)",
 )
+@check_root
 def mount(iso_path, domain_name):
     """Inject ISO file into specified guest vm.
     Domain can be retrieved by running "xl list" command on the host.

--- a/drakrun/cli/postinstall.py
+++ b/drakrun/cli/postinstall.py
@@ -8,10 +8,13 @@ from drakrun.lib.paths import INSTALL_INFO_PATH
 from drakrun.lib.vm import VirtualMachine
 from drakrun.lib.vmi_profile import create_vmi_info, create_vmi_json_profile
 
+from .check_root import check_root
+
 log = logging.getLogger(__name__)
 
 
 @click.command(help="Finalize VM installation")
+@check_root
 def postinstall():
     config = load_config()
     install_info = InstallInfo.load(INSTALL_INFO_PATH)

--- a/drakrun/cli/postprocess.py
+++ b/drakrun/cli/postprocess.py
@@ -2,10 +2,6 @@ import pathlib
 
 import click
 
-from drakrun.analyzer.postprocessing import (
-    append_metadata_to_analysis,
-    postprocess_analysis_dir,
-)
 from drakrun.lib.config import load_config
 
 
@@ -18,6 +14,11 @@ def postprocess(output_dir):
     """
     Run postprocessing on analysis output
     """
+    from drakrun.analyzer.postprocessing import (
+        append_metadata_to_analysis,
+        postprocess_analysis_dir,
+    )
+
     config = load_config()
     output_dir = pathlib.Path(output_dir)
     extra_metadata = postprocess_analysis_dir(output_dir, config)

--- a/drakrun/cli/vm_start.py
+++ b/drakrun/cli/vm_start.py
@@ -5,6 +5,8 @@ from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.paths import INSTALL_INFO_PATH
 from drakrun.lib.vm import VirtualMachine
 
+from .check_root import check_root
+
 
 @click.command(help="Start VM from snapshot")
 @click.option(
@@ -15,6 +17,7 @@ from drakrun.lib.vm import VirtualMachine
     show_default=True,
     help="VM id to use for generating profile",
 )
+@check_root
 def vm_start(vm_id: int):
     config = load_config()
     install_info = InstallInfo.load(INSTALL_INFO_PATH)

--- a/drakrun/cli/vm_stop.py
+++ b/drakrun/cli/vm_stop.py
@@ -5,6 +5,8 @@ from drakrun.lib.install_info import InstallInfo
 from drakrun.lib.paths import INSTALL_INFO_PATH
 from drakrun.lib.vm import VirtualMachine
 
+from .check_root import check_root
+
 
 @click.command(help="Stop VM and cleanup network")
 @click.option(
@@ -15,6 +17,7 @@ from drakrun.lib.vm import VirtualMachine
     show_default=True,
     help="VM id to use for generating profile",
 )
+@check_root
 def vm_stop(vm_id: int):
     config = load_config()
     install_info = InstallInfo.load(INSTALL_INFO_PATH)

--- a/drakrun/cli/worker.py
+++ b/drakrun/cli/worker.py
@@ -1,6 +1,6 @@
 import click
 
-from drakrun.analyzer.worker import worker_main
+from .check_root import check_root
 
 
 @click.command(help="Start drakrun analysis worker")
@@ -12,5 +12,8 @@ from drakrun.analyzer.worker import worker_main
     show_default=True,
     help="VM id to use for running analyses",
 )
+@check_root
 def worker(vm_id: int):
+    from drakrun.analyzer.worker import worker_main
+
     worker_main(vm_id)

--- a/drakrun/lib/config.py
+++ b/drakrun/lib/config.py
@@ -33,7 +33,7 @@ class DrakrunConfigSection(BaseModel):
     model_config = ConfigDict(extra="ignore")
     plugins: List[str]
     default_timeout: int
-    job_timeout_leeway: int = 300
+    job_timeout_leeway: int = 600
     net_enable: Optional[bool] = None
     apimon_hooks_path: Optional[pathlib.Path] = None
     syscall_hooks_path: Optional[pathlib.Path] = None
@@ -56,6 +56,7 @@ class DrakrunDefaultsPresetSection(BaseModel):
     extra_output_subdirs: Optional[List[str]] = None
     no_post_restore: Optional[bool] = None
     no_screenshotter: Optional[bool] = None
+    gzip_syscalls: Optional[bool] = False
 
 
 class CapaConfigSection(BaseModel):


### PR DESCRIPTION
Fix for various issues found during documentation writing:

- root is not required for all CLI commands
- commands requiring `drakrun.analyzer` perform lazy import. It takes few seconds to load everything and it's not necessary to perform it on every command.
- changed job_timeway_leeway to 600 seconds (current 300 default may be annoying)
- `gzip_syscalls` is also accepted as a part of preset
- `drakrun drakvuf-cmdline` should not require a running VM