### PR TITLE
Fix: missing log for extract_dll_profile

### DIFF
--- a/drakrun/lib/vmi_profile.py
+++ b/drakrun/lib/vmi_profile.py
@@ -24,6 +24,8 @@ def extract_dll_profile(injector: Injector, dll: DLL):
     local_dll_path = (tempdir / dll.dest).as_posix()
     guest_dll_path = str(pathlib.PureWindowsPath("C:/", dll.path))
 
+    log.info("Generating VMI profile for %s", local_dll_path)
+
     proc = injector.read_file(guest_dll_path, local_dll_path)
     out = json.loads(proc.stdout.decode())
     if out["Status"] == "Error" and out["Error"] in [


### PR DESCRIPTION
After changing logging configuration, we don't see any useful log during VMI profile generation (only progress bars). This PR adds additional logging to the extract_dll_profile function.