### PR TITLE
drakshell: build for generic x86-64 target to increase compatibility

### DIFF
--- a/drakrun/tools/drakshell/Makefile
+++ b/drakrun/tools/drakshell/Makefile
@@ -1,5 +1,5 @@
 IDIR =./include
-CFLAGS=-I$(IDIR) -fPIE -nostdlib -ffreestanding -masm=intel -march=x86-64 -fshort-wchar -O2 -mno-avx
+CFLAGS=-I$(IDIR) -fPIE -nostdlib -ffreestanding -masm=intel -march=x86-64 -mtune=generic -fshort-wchar -O2
 LFLAGS=-T linker.ld
 ODIR=obj
 


### PR DESCRIPTION
resolve #1130

The current compiler setting for building `drakshell` payload causes unnecessary dependency on vectorizing instructions. This causes a crash on nested virtualization (VMware Hypervisor -> Xen@Ubuntu 22.04 -> Windows 10 22H2) which would otherwise be avoidable.

This patch does actually fix this issue.

<img width="1047" height="833" alt="image" src="https://github.com/user-attachments/assets/0040bccb-50cc-4189-8d13-de04c8c996f4" />


In the meantime, I propose to build for a generic `x86-64` instead of `haswell` to effectively disable the usage of most CPU extensions in general. The `drakshell` is a critical component of DRAKVUF Sandbox for now, and it essentially prevents to use the sandbox if it doesn't work for any reason. Thus, I guess the most generic possible build would be best to avoid any issues in the future.

The Windows 10 22H2 doesn't seem to be reliant on whether AVX is supported or not, everything seems to be working just fine. Of course certain 3rd party usermode apps might be crashing if they explicitly rely on AVX, but it doesn't seem to be the case for Windows userland/kernel itself.