### PR TITLE
dev: Add basic docker compose for web development

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,1 @@
+config.toml

--- a/dev/backend.Dockerfile
+++ b/dev/backend.Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12
+
+COPY ./drakrun /app/drakrun
+COPY ./setup.py ./requirements.txt ./pyproject.toml ./MANIFEST.in /app/
+
+WORKDIR /app/
+RUN pip install .
+CMD ["flask", "--app", "drakrun.web.app:app", "run", "--with-threads", "--host", "0.0.0.0", "--port", "8080"]

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -1,0 +1,18 @@
+services:
+  redis:
+    image: "redis:latest"
+    command: '--requirepass redisPassword'
+
+  backend:
+    build:
+      context: ..
+      dockerfile: ./dev/backend.Dockerfile
+    volumes:
+      - "./config.toml:/etc/drakrun/config.toml"
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: ./dev/frontend.Dockerfile
+    ports:
+      - "3000:3000"

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -1,0 +1,23 @@
+# Copy this file to config.toml
+#
+# If you want to connect it to the remote worker instance:
+# - change [redis] so it points to the Redis host shared with worker
+# - uncomment and change [s3] section so it points to the S3 host shared with worker
+
+[redis]
+host = "redis."
+port = 6379
+
+# [s3]
+# address = "https://<address>"
+# access_key = "<access-key>"
+# secret_key = "<secret-key>"
+
+[network]
+dns_server = "use-gateway-address"
+out_interface = "default"
+net_enable = false
+
+[drakrun]
+default_timeout = 300
+plugins = ["apimon", "clipboardmon", "exmon", "filetracer", "memdump", "procmon", "regmon", "socketmon", "tlsmon"]

--- a/dev/frontend.Dockerfile
+++ b/dev/frontend.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+COPY ./drakrun/web/frontend /app
+RUN cd /app \
+    && npm install --unsafe-perm . \
+    && CI=true npm run build \
+    && npm cache clean --force
+
+ENV PROXY_BACKEND_URL=http://backend.:8080
+WORKDIR /app
+CMD ["npm", "run", "dev"]

--- a/drakrun/web/frontend/vite.config.js
+++ b/drakrun/web/frontend/vite.config.js
@@ -3,8 +3,22 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-  define: {
+    plugins: [react()],
+    define: {
         '__APP_VERSION__': JSON.stringify(process.env.npm_package_version),
-  }
+    },
+    // dev-server
+    server: {
+        host: "0.0.0.0",
+        port: 3000,
+        strictPort: true,
+        proxy: (
+            process.env.PROXY_BACKEND_URL ? {
+                "/api": {
+                    target: process.env.PROXY_BACKEND_URL,
+                    changeOrigin: true,
+                },
+            } : {}
+        ),
+    }
 })


### PR DESCRIPTION
In future we want to support multi-node instances with centralized frontend/API. 

This compose is going to be a good start for that feature e.g. right now we don't have access to VNC in that separate instance.