### PR TITLE
Fix: 'NoneType' object has no attribute 'ts_to' in process_tree postprocessor

### DIFF
--- a/drakrun/analyzer/postprocessing/process_tree.py
+++ b/drakrun/analyzer/postprocessing/process_tree.py
@@ -293,7 +293,11 @@ def tree_from_log(file: TextIO) -> ProcessTree:
                     pid = entry["PID"]
                     ppid = entry["PPID"]
                     process = pstree.get_process(pid)
-                    if process.ts_to is None and process.ppid != ppid:
+                    if (
+                        process is not None
+                        and process.ts_to is None
+                        and process.ppid != ppid
+                    ):
                         # Found elevated process: rebind to another parent
                         new_parent = pstree.get_process(ppid)
                         if new_parent is not None:


### PR DESCRIPTION
Sometimes Drakvuf fetches process list in the middle of process creation, so it's not guaranteed that process can be found.

This PR fixes the following error:
```
Traceback (most recent call last):
File "/opt/venv/lib/python3.11/site-packages/drakrun/analyzer/postprocessing/postprocess.py", line 39, in run_postprocessing
plugin.function(context)
File "/opt/venv/lib/python3.11/site-packages/drakrun/analyzer/postprocessing/plugins/build_process_tree.py", line 16, in build_process_tree
process_tree = tree_from_log(procmon_log)
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/venv/lib/python3.11/site-packages/drakrun/analyzer/postprocessing/process_tree.py", line 306, in tree_from_log
raise e
File "/opt/venv/lib/python3.11/site-packages/drakrun/analyzer/postprocessing/process_tree.py", line 296, in tree_from_log
if process.ts_to is None and process.ppid != ppid:
^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'ts_to'
```