### PR TITLE
Fix: Use hostname in worker names to avoid collisions in distributed setups

### DIFF
--- a/drakrun/analyzer/worker.py
+++ b/drakrun/analyzer/worker.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import shutil
+import socket
 from typing import List, Optional
 
 from redis import Redis
@@ -160,9 +161,11 @@ def worker_main(vm_id: int):
     global _WORKER_VM_ID
     _WORKER_VM_ID = vm_id
     config = load_config()
+    hostname = config.drakrun.worker_hostname or socket.gethostname()
+
     worker = Worker(
         queues=[ANALYSIS_QUEUE_NAME],
-        name=f"drakrun-worker-vm-{vm_id}",
+        name=f"drakrun-worker@{hostname}:vm-{vm_id}",
         connection=get_redis_connection(config.redis),
     )
     worker.work()

--- a/drakrun/lib/config.py
+++ b/drakrun/lib/config.py
@@ -45,6 +45,9 @@ class DrakrunConfigSection(BaseModel):
     gzip_syscalls: bool = False
     use_7zip: bool = False
     path_to_7zip: str = "C:/Program Files/7-Zip/7z.exe"
+    # Override hostname used in worker names on this host.
+    # It gets automatically detected if not set.
+    worker_hostname: Optional[str] = None
 
 
 class DrakrunDefaultsPresetSection(BaseModel):


### PR DESCRIPTION
Worker names previously depended only on the VM ID, which caused collisions in multi-host deployments.

This change includes the hostname in worker names (similar to Celery’s default naming), ensuring uniqueness and allowing VM IDs to be reused across hosts. If the system hostname is not suitable or not unique, it can be overridden via configuration.