### PR TITLE
Fix: 7zip - use 'x' command instead of 'e'

### DIFF
--- a/drakrun/analyzer/analyzer.py
+++ b/drakrun/analyzer/analyzer.py
@@ -150,7 +150,7 @@ def extract_archive_on_vm(
         )
         command = [
             config.drakrun.path_to_7zip,
-            "e",
+            "x",
             str(guest_archive_resolved_path),
             "-o" + str(guest_extraction_dir),
             *(["-p" + archive_password] if archive_password else []),


### PR DESCRIPTION
I don't know what I had in mind while using `e : Extract files from archive (without using directory names)` instead of `x : eXtract files with full paths` but right now files are unpacked incorrectly when there is directory tree in the archive (tree is flattened)

This PR changes command from `e` to `x`.