### PR TITLE
Fix networking: drop traffic between VMs, drop conntrack during stop_vm_network

### DIFF
--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -193,7 +193,7 @@ Check if ``drakvuf`` and ``injector`` commands load correctly:
 .. code-block:: console
 
     $ apt update
-    $ apt install iptables tcpdump dnsmasq qemu-utils bridge-utils libmagic1 python3-venv redis-server
+    $ apt install iptables tcpdump dnsmasq qemu-utils bridge-utils libmagic1 python3-venv redis-server conntrack
 
 2. Prepare virtualenv
 

--- a/drakrun/lib/networking.py
+++ b/drakrun/lib/networking.py
@@ -133,6 +133,8 @@ def setup_iptables_chains() -> None:
         "-A FORWARD -j DRAKRUN_FWD",
         "-N DRAKRUN_PRT -t nat",
         "-A POSTROUTING -j DRAKRUN_PRT -t nat",
+        # Don't forward traffic between VM bridges (isolate)
+        "-A DRAKRUN_FWD -i drak+ -o drak+ -j DROP",
     ]
     exists = [
         iptable_rule_exists("INPUT -j DRAKRUN_INP"),
@@ -330,6 +332,25 @@ def delete_vm_bridge(bridge_name: str):
         log.info(f"Deleted {bridge_name} bridge")
 
 
+def drop_outgoing_conntrack(vm_ip: str):
+    # NAT state needs to be flushed, so we don't
+    # get traffic from the previous VM instance
+    try:
+        subprocess.run(
+            f"conntrack -D -s {vm_ip}",
+            shell=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        log.warning(
+            f"Failed to flush conntrack for {vm_ip}. "
+            f"Ensure that 'conntrack' is installed on the host "
+            f"and works correctly."
+        )
+    else:
+        log.info(f"Flushed conntrack for {vm_ip}")
+
+
 def vm_network_exists(vm_id: int):
     network_info_path = get_network_info_path(vm_id)
     return network_info_path.exists()
@@ -367,6 +388,7 @@ def stop_vm_network(vm_id: int):
         del_iptable_rule(f"DRAKRUN_FWD -i {bridge_name} -o {out_interface} -j ACCEPT")
         del_iptable_rule(f"DRAKRUN_FWD -i {out_interface} -o {bridge_name} -j ACCEPT")
 
+    drop_outgoing_conntrack(network_info.vm_address)
     run_network_setup_script("vmnet-post-down.sh", network_info)
     network_info_path.unlink()
 

--- a/drakrun/lib/networking.py
+++ b/drakrun/lib/networking.py
@@ -337,7 +337,7 @@ def drop_outgoing_conntrack(vm_ip: str):
     # get traffic from the previous VM instance
     try:
         subprocess.run(
-            f"conntrack -D -s {vm_ip}",
+            ["conntrack", "-D", "-s", vm_ip],
             shell=True,
             check=True,
         )


### PR DESCRIPTION
We've observed unexpected incoming traffic in pcap that was caused by connections initiated by previous VM instance that was using the same bridge. Even if bridge is dropped between analyses, connections are still tracked in NAT and assured in conntrack.

While debugging this issue I have also observed that we don't drop forwards between VM bridges, so parallel VMs are able to each other.

This PR:
- adds `-A DRAKRUN_FWD -i drak+ -o drak+ -j DROP` rule that drops `FORWARD` between drak bridges
- calls `conntrack -D -s <vm_ip>` when vmnet is stopped. Conntrack is not installed by default on Debian, so failed invocation emits proper warning.