### PR TITLE
Feat/add priority to jobs

### DIFF
--- a/drakrun/analyzer/analysis_options.py
+++ b/drakrun/analyzer/analysis_options.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from drakrun.lib.config import DrakrunConfig
 
 StartMethod = Literal["createproc", "shellexec", "runas"]
+JobPriority = Literal["low", "normal", "high"]
 
 
 class AnalysisOptions(BaseModel):

--- a/drakrun/analyzer/worker.py
+++ b/drakrun/analyzer/worker.py
@@ -19,10 +19,14 @@ from ..lib.s3_storage import (
     upload_analysis,
 )
 from .analysis_metadata import AnalysisMetadata, FileMetadata
-from .analysis_options import AnalysisOptions
+from .analysis_options import AnalysisOptions, JobPriority
 from .analyzer import AnalysisSubstatus, analyze_file
 
-ANALYSIS_QUEUE_NAME = "drakrun-analysis"
+ANALYSIS_QUEUE_NAMES = {
+    "high": "drakrun-analysis-high",
+    "normal": "drakrun-analysis-normal",
+    "low": "drakrun-analysis-low",
+}
 _WORKER_VM_ID: Optional[int] = None
 
 logger = logging.getLogger(__name__)
@@ -53,6 +57,7 @@ def analysis_job_to_metadata(job: Job) -> AnalysisMetadata:
             "options": job_meta["options"],
             "file": job_meta["file"],
             "vm_id": job_meta.get("vm_id"),
+            "priority": job_meta.get("priority", "normal"),
             "time_started": (
                 job.started_at.isoformat() if job.started_at is not None else None
             ),
@@ -168,7 +173,7 @@ def worker_main(vm_id: int):
     hostname = config.drakrun.worker_hostname or socket.gethostname()
 
     worker = Worker(
-        queues=[ANALYSIS_QUEUE_NAME],
+        queues=list(ANALYSIS_QUEUE_NAMES.values()),
         name=f"drakrun-worker@{hostname}:vm-{vm_id}",
         connection=get_redis_connection(config.redis),
     )
@@ -181,8 +186,10 @@ def enqueue_analysis(
     options: AnalysisOptions,
     connection: Redis,
     result_ttl: int,
+    priority: JobPriority = "normal",
 ) -> Job:
-    queue = Queue(name=ANALYSIS_QUEUE_NAME, connection=connection)
+    queue_name = ANALYSIS_QUEUE_NAMES[priority]
+    queue = Queue(name=queue_name, connection=connection)
     if options.timeout is None:
         raise RuntimeError("Timeout is required when spawning analysis to worker")
     return queue.enqueue(
@@ -192,6 +199,7 @@ def enqueue_analysis(
         meta={
             "options": options.to_dict(exclude_none=True),
             "file": file_metadata.to_dict(),
+            "priority": priority,
         },
         job_timeout=options.timeout + options.job_timeout_leeway,
         result_ttl=result_ttl,
@@ -199,21 +207,23 @@ def enqueue_analysis(
 
 
 def get_analyses_list(connection: Redis) -> List[Job]:
-    queue = Queue(name=ANALYSIS_QUEUE_NAME, connection=connection)
-    jobs = list(queue.get_jobs())
-    for job_registry in [
-        queue.started_job_registry,
-        queue.finished_job_registry,
-        queue.failed_job_registry,
-    ]:
-        job_ids = job_registry.get_job_ids()
-        jobs.extend(
-            [
-                job
-                for job in Job.fetch_many(job_ids, connection=connection)
-                if job is not None
-            ]
-        )
+    jobs = []
+    for queue_name in ANALYSIS_QUEUE_NAMES.values():
+        queue = Queue(name=queue_name, connection=connection)
+        jobs.extend(queue.get_jobs())
+        for job_registry in [
+            queue.started_job_registry,
+            queue.finished_job_registry,
+            queue.failed_job_registry,
+        ]:
+            job_ids = job_registry.get_job_ids()
+            jobs.extend(
+                [
+                    job
+                    for job in Job.fetch_many(job_ids, connection=connection)
+                    if job is not None
+                ]
+            )
     return sorted(jobs, key=lambda job: job.enqueued_at, reverse=True)
 
 

--- a/drakrun/web/api.py
+++ b/drakrun/web/api.py
@@ -72,6 +72,7 @@ def upload_sample(form: UploadFileForm):
     start_method = form.start_method
     plugins = form.plugins
     preset = form.preset
+    priority = form.priority or "normal"
     no_internet = form.no_internet
     no_screenshots = form.no_screenshots
 
@@ -134,6 +135,7 @@ def upload_sample(form: UploadFileForm):
             options=analysis_options,
             connection=redis,
             result_ttl=config.drakrun.result_ttl,
+            priority=priority,
         )
     except Exception:
         tmp_upload_path.unlink(missing_ok=True)

--- a/drakrun/web/frontend/src/AnalysisList.jsx
+++ b/drakrun/web/frontend/src/AnalysisList.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { getAnalysisList } from "./api";
 import { CanceledError } from "axios";
 import { AnalysisStatusBadge } from "./AnalysisStatusBadge.jsx";
+import { AnalysisPriorityBadge } from "./AnalysisPriorityBadge.jsx";
 import { formatDate } from "./formatUtils.js";
 
 function AnalysisListRow({ analysis }) {
@@ -10,6 +11,7 @@ function AnalysisListRow({ analysis }) {
         <tr>
             <td>
                 <AnalysisStatusBadge status={analysis.status} />
+                <AnalysisPriorityBadge priority={analysis.priority} />
                 <Link to={`/analysis/${analysis.id}`}>{analysis.id}</Link>
             </td>
             <td>

--- a/drakrun/web/frontend/src/AnalysisPriorityBadge.jsx
+++ b/drakrun/web/frontend/src/AnalysisPriorityBadge.jsx
@@ -1,0 +1,13 @@
+export function AnalysisPriorityBadge({ priority }) {
+    const priorityStyle =
+        {
+            low: "bg-secondary",
+            normal: "bg-light text-dark",
+            high: "bg-warning text-dark",
+        }[priority] || "bg-light text-dark";
+    return (
+        <div className={`badge ${priorityStyle} me-2 p-2`}>
+            {priority || "normal"}
+        </div>
+    );
+}

--- a/drakrun/web/frontend/src/UploadView.jsx
+++ b/drakrun/web/frontend/src/UploadView.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useCallback, useRef, useState } from "react";
 import { uploadSample } from "./api.js";
 
+const PRIORITY_LEVELS = ["low", "normal", "high"];
+
 function FormError({ errors, field }) {
     const error = errors[field];
     if (error) {
@@ -72,6 +74,7 @@ function UploadForm() {
     const [formErrors, setFormErrors] = useState({});
     const [error, setError] = useState();
     const [analysisTime, setAnalysisTime] = useState(10);
+    const [priority, setPriority] = useState("normal");
     const [extractArchive, setExtractArchive] = useState(false);
     const [extraOptionsCollapsed, setExtraOptionsCollapsed] = useState(true);
     const navigate = useNavigate();
@@ -118,6 +121,7 @@ function UploadForm() {
                 const jobData = await uploadSample({
                     file: form.get("file"),
                     timeout: form.get("timeout") * 60,
+                    priority: form.get("priority"),
                     plugins: form.getAll("plugins"),
                     file_name: form.get("file_name"),
                     file_path: form.get("file_path"),
@@ -168,6 +172,24 @@ function UploadForm() {
                     id="form-timeout"
                     name="timeout"
                 />
+            </div>
+            <div className="mb-3">
+                <label htmlFor="form-priority" className="form-label">
+                    Priority: {priority}
+                </label>
+                <input
+                    type="range"
+                    className="form-range"
+                    min="0"
+                    max="2"
+                    step="1"
+                    value={PRIORITY_LEVELS.indexOf(priority)}
+                    onChange={(ev) =>
+                        setPriority(PRIORITY_LEVELS[+ev.target.value])
+                    }
+                    id="form-priority"
+                />
+                <input type="hidden" name="priority" value={priority} />
             </div>
             <div className="mb-3 form-check">
                 <input

--- a/drakrun/web/frontend/src/api.js
+++ b/drakrun/web/frontend/src/api.js
@@ -117,6 +117,7 @@ export async function getAnalysisFileList({
 export async function uploadSample({
     file,
     timeout,
+    priority,
     file_name,
     file_path,
     plugins,
@@ -132,6 +133,7 @@ export async function uploadSample({
     const formData = new FormData();
     formData.append("file", file);
     formData.append("timeout", timeout);
+    if (priority) formData.append("priority", priority);
     formData.append("plugins", JSON.stringify(plugins));
     if (file_name) formData.append("file_name", file_name);
     if (file_path) formData.append("file_path", file_path);

--- a/drakrun/web/schema.py
+++ b/drakrun/web/schema.py
@@ -4,7 +4,7 @@ from typing import Annotated, List, Optional
 from flask_openapi3 import FileStorage
 from pydantic import AfterValidator, BaseModel, Field, RootModel
 
-from drakrun.analyzer.analysis_options import StartMethod
+from drakrun.analyzer.analysis_options import JobPriority, StartMethod
 
 
 class APIErrorResponse(BaseModel):
@@ -27,6 +27,9 @@ class UploadFileForm(BaseModel):
         default=None, description="Plugins to use (in JSON array string)"
     )
     preset: Optional[str] = Field(default=None, description="Analysis settings preset")
+    priority: Optional[JobPriority] = Field(
+        default="normal", description="Job priority"
+    )
     no_internet: Optional[bool] = Field(
         default=False, description="Disable Internet connection"
     )


### PR DESCRIPTION
This feature allows assigning priority to jobs directly from drakvuf-sandbox. The following changes were made:
- the current `drakrun-analysis` queue is replaced with 3 separate queues:  `drakrun-analysis-high`,  `drakrun-analysis-normal` and  `drakrun-analysis-low`
- the RQ worker uses the three queue names in priority order, only fetching from the lower priority queues if the higher priority queues are empty
- the `upload` api endpoint now accepts a `priority` string parameter, matching the 3 priority levels ("low", "normal", "high"). A default of normal is used if the parameter is omitted
- the upload page in the web UI has a slider that allows selecting a priority for the job
- a priority badge is added to the analyses list, akin to the existing status badge, that shows its priority level

Screenshots:
<img width="1791" height="775" alt="image" src="https://github.com/user-attachments/assets/1c2fd227-bb23-464a-8722-a629f28730a2" />

<img width="1256" height="750" alt="image" src="https://github.com/user-attachments/assets/7a59c628-dbb4-4e44-93de-0254e63f20f0" />

<img width="884" height="428" alt="image" src="https://github.com/user-attachments/assets/1599b829-db23-424b-8e3e-5fcfa81b9bc3" />